### PR TITLE
[Fix] Assets/private 폴더가 자꾸 수정사항에 추적되는 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ crashlytics-build.properties
 
 # Ignore VSCode folder
 .vscode/
+
+# Ignore private assets folder path
+/[Aa]ssets/private/


### PR DESCRIPTION
### 오류 사항
* private 폴더 내에 수정 사항이 생기든, 수정 사항이 생기지 않든 계속 file change가 추적되어 커밋이 가능한 오류가 생겼습니다.

### 변경 사항
* gitignore에 Assets/private 폴더 경로를 작성했고, 이후 추적되지 않는 것을 확인했습니다.
