### PR TITLE
[Feature] 2인용 퍼즐 시작 가능 조건 시각화 구현

### DIFF
--- a/Assets/Scenes/PrisonScene.unity
+++ b/Assets/Scenes/PrisonScene.unity
@@ -197,6 +197,90 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 19508676}
   m_CullTransparentMesh: 1
+--- !u!1 &222089048
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 222089049}
+  - component: {fileID: 222089050}
+  m_Layer: 0
+  m_Name: PipeInteractZonePlayerCounter2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &222089049
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222089048}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.947, y: -1.427, z: -0.03}
+  m_LocalScale: {x: 0.08448, y: 0.08448, z: 0.084479995}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 812403688}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &222089050
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 222089048}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.15164173, g: 0.076317206, b: 0.3301887, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &265958728
 GameObject:
   m_ObjectHideFlags: 0
@@ -5850,6 +5934,8 @@ Transform:
   - {fileID: 822678604}
   - {fileID: 265958729}
   - {fileID: 635386917}
+  - {fileID: 1054376980}
+  - {fileID: 222089049}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &822678603
@@ -6419,6 +6505,90 @@ SpriteRenderer:
   m_FlipY: 0
   m_DrawMode: 0
   m_Size: {x: 22.564125, y: 16.240002}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1 &1054376979
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1054376980}
+  - component: {fileID: 1054376981}
+  m_Layer: 0
+  m_Name: PipeInteractZonePlayerCounter1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1054376980
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1054376979}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.778, y: -1.427, z: -0.03}
+  m_LocalScale: {x: 0.08447697, y: 0.08447697, z: 0.08447697}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 812403688}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1054376981
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1054376979}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0.15164173, g: 0.076317206, b: 0.3301887, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Assets/Scenes/PrisonScene.unity
+++ b/Assets/Scenes/PrisonScene.unity
@@ -8747,6 +8747,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isPlayer1In: 0
   isPlayer2In: 0
+  pipeInteractZonePlayerCounter1: {fileID: 1054376979}
+  pipeInteractZonePlayerCounter2: {fileID: 222089048}
 --- !u!61 &2054068920
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Script/PrisonInteractScript/PipeInteractZoneScript.cs
+++ b/Assets/Script/PrisonInteractScript/PipeInteractZoneScript.cs
@@ -7,6 +7,11 @@ public class PipeInteractZone : MonoBehaviour
     // 플레이어가 들어왔는지 확인하기 위한 변수
     public bool isPlayer1In = false;
     public bool isPlayer2In = false;
+    // 현재 상호작용 존 안의 총 플레이어 수 변수
+    private int zonePlayerCounter = 0;
+    // 시각적으로 플레이어 수를 보여줄 게임오브젝트 변수
+    public GameObject pipeInteractZonePlayerCounter1;
+    public GameObject pipeInteractZonePlayerCounter2;
 
     // 플레이어가 구역에 들어온다면 true, 나가면 false (태그로 구분)
     private void OnTriggerEnter2D(Collider2D other)

--- a/Assets/Script/PrisonInteractScript/PipeInteractZoneScript.cs
+++ b/Assets/Script/PrisonInteractScript/PipeInteractZoneScript.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using ExitGames.Client.Photon.StructWrapping;
 using UnityEngine;
 
 public class PipeInteractZone : MonoBehaviour
@@ -25,7 +26,12 @@ public class PipeInteractZone : MonoBehaviour
         {
             isPlayer2In = true;
         }
+        // 어떤 플레이어든 상호작용 존에 들어온다면 플레이어 카운터 변수 +1
+        zonePlayerCounter++;
+        // 플레이어 수에 따라 불빛 개수 갱신
+        UpdatePlayerCounter();
     }
+
     private void OnTriggerExit2D(Collider2D other)
     {
         if (other.CompareTag("Player1"))
@@ -36,6 +42,31 @@ public class PipeInteractZone : MonoBehaviour
         else if (other.CompareTag("Player2"))
         {
             isPlayer2In = false;
+        }
+        // 어떤 플레이어든 상호작용 존에서 나간다면 플레이어 카운터 변수 -1
+        zonePlayerCounter--;
+        // 플레이어 수에 따라 불빛 개수 갱신
+        UpdatePlayerCounter();
+    }
+
+    // 현재 상호작용 존 안의 플레이어 수에 따라 불빛 개수를 갱신하는 함수
+    void UpdatePlayerCounter()
+    {
+        // 최대 플레이어는 2명, 가능한 경우의 수는 0,1,2이므로 if-else로 작성
+        if(zonePlayerCounter == 0)
+        {
+            pipeInteractZonePlayerCounter1.GetComponent<SpriteRenderer>().color = new Color(0.152f, 0.075f, 0.329f);
+            pipeInteractZonePlayerCounter2.GetComponent<SpriteRenderer>().color = new Color(0.152f, 0.075f, 0.329f);
+        }
+        else if(zonePlayerCounter == 1)
+        {
+            pipeInteractZonePlayerCounter1.GetComponent<SpriteRenderer>().color = Color.white;
+            pipeInteractZonePlayerCounter2.GetComponent<SpriteRenderer>().color = new Color(0.152f, 0.075f, 0.329f);
+        }
+        else if(zonePlayerCounter == 2)
+        {
+            pipeInteractZonePlayerCounter1.GetComponent<SpriteRenderer>().color = Color.white;
+            pipeInteractZonePlayerCounter2.GetComponent<SpriteRenderer>().color = Color.white;
         }
     }
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/2a87e2ec-d010-457a-b857-d42de945d4fc

### 구현된 기능
* 2인용 퍼즐에서 상호작용 존에 들어온 플레이어의 수에 따라 조명 불빛 개수가 달라지도록 구현했습니다

### 참고사항
* 일단은 동그란 오브젝트 2개로 하긴 했는데.. 뭔가 어울리거나 더 나은 이미지가 있을 것 같다 하면 말씀해 주세용

### Merge 데드라인
* 적어도 10월 15일까지는 리뷰 - 승인 부탁합니다아