### PR TITLE
[Fix] 감옥 문 테두리 깨짐현상 수정

### DIFF
--- a/Assets/Scenes/PrisonScene.unity
+++ b/Assets/Scenes/PrisonScene.unity
@@ -521,7 +521,7 @@ Transform:
   m_GameObject: {fileID: 443638698}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -11.62, y: 5.36, z: -0.6}
+  m_LocalPosition: {x: -11.15, y: 5.12, z: -0.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -590,7 +590,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 789cf6336a550f149a3a82a3787f55fb, type: 2}
+  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
   objectIndex: 4
   stageManager: {fileID: 1558506330}
   playerLocation: {fileID: 443638704}
@@ -6211,7 +6211,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 789cf6336a550f149a3a82a3787f55fb, type: 2}
+  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
   objectIndex: 3
   stageManager: {fileID: 1558506330}
   playerLocation: {fileID: 443638704}
@@ -6470,7 +6470,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 789cf6336a550f149a3a82a3787f55fb, type: 2}
+  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
   objectIndex: 2
   stageManager: {fileID: 1558506330}
   pipeInteractZone: {fileID: 2054068919}
@@ -6741,7 +6741,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 789cf6336a550f149a3a82a3787f55fb, type: 2}
+  canInteractState: {fileID: 2100000, guid: 1a0517ea99bbc3e45bc921cbe1b5dec6, type: 2}
   objectIndex: 1
   stageManager: {fileID: 1558506330}
   playerLocation: {fileID: 443638704}
@@ -6787,7 +6787,7 @@ PolygonCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.91, y: 1.26}
+    oldSize: {x: 1.11, y: 1.26}
     newSize: {x: 0.91, y: 1.26}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -6841,7 +6841,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 825a67ae90a5fcf45b02fc7c6cadd81f, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 698acbec27c6915499036c2360246f27, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -7108,7 +7108,7 @@ Transform:
   m_GameObject: {fileID: 1279382546}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.53, y: 3.53, z: -0.6}
+  m_LocalPosition: {x: -5.76, y: 5.18, z: -0.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -7630,7 +7630,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 789cf6336a550f149a3a82a3787f55fb, type: 2}
+  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
   objectIndex: 5
   stageManager: {fileID: 1558506330}
   playerLocation: {fileID: 443638704}
@@ -7875,7 +7875,7 @@ Transform:
   m_GameObject: {fileID: 1722749263}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -12.27, y: 2.91, z: -0.61}
+  m_LocalPosition: {x: -12.23, y: 2.91, z: -0.61}
   m_LocalScale: {x: 1.5, y: 1.5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -7894,7 +7894,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 789cf6336a550f149a3a82a3787f55fb, type: 2}
+  canInteractState: {fileID: 2100000, guid: 1a0517ea99bbc3e45bc921cbe1b5dec6, type: 2}
   objectIndex: 0
   stageManager: {fileID: 1558506330}
   playerLocation: {fileID: 443638704}
@@ -7940,7 +7940,7 @@ PolygonCollider2D:
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.91, y: 1.26}
+    oldSize: {x: 1.11, y: 1.26}
     newSize: {x: 0.91, y: 1.26}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
@@ -7994,7 +7994,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: 825a67ae90a5fcf45b02fc7c6cadd81f, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 698acbec27c6915499036c2360246f27, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -8668,7 +8668,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 789cf6336a550f149a3a82a3787f55fb, type: 2}
+  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
   objectIndex: 6
   stageManager: {fileID: 1558506330}
   playerLocation: {fileID: 443638704}
@@ -8827,7 +8827,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 789cf6336a550f149a3a82a3787f55fb, type: 2}
+  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
   objectIndex: 7
   stageManager: {fileID: 1558506330}
   playerLocation: {fileID: 443638704}

--- a/Assets/SpriteOutline/Shaders/SpriteOutline.shader
+++ b/Assets/SpriteOutline/Shaders/SpriteOutline.shader
@@ -1,4 +1,4 @@
-﻿Shader "Sprites/Outline"
+Shader "Sprites/Outline"
 {
     Properties
     {
@@ -9,7 +9,7 @@
 		[MaterialToggle] _OutlineEnabled ("Outline Enabled", Float) = 1
 		[MaterialToggle] _ConnectedAlpha ("Connected Alpha", Float) = 0
         [HideInInspector] _AlphaThreshold ("Alpha clean", Range (0, 1)) = 0
-        _Thickness ("Width (Max recommended 100)", float) = 10
+        _Thickness ("Width (Max recommended 100)", float) = 3
 		[KeywordEnum(Solid, Gradient, Image)] _OutlineMode("Outline mode", Float) = 0
 		[KeywordEnum(Contour, Frame)] _OutlineShape("Outline shape", Float) = 0
 		[KeywordEnum(Inside under sprite, Inside over sprite, Outside)] _OutlinePosition("Outline Position (Frame Only)", Float) = 0

--- a/Assets/Sprites/OutlineMaterial/DoorInteractShader.shader
+++ b/Assets/Sprites/OutlineMaterial/DoorInteractShader.shader
@@ -1,0 +1,108 @@
+Shader "Sprites/DoorOutline" {
+    Properties {
+        [PerRendererData] _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Main texture Tint", Color) = (1,1,1,1)
+
+        _OutlineColor ("Outline Color", Color) = (0,0,0,1)
+        _OutlineSize ("Outline Width", Range(0.0, 0.05)) = 0.02
+
+        [Header(General Settings)]
+        [MaterialToggle] _OutlineEnabled ("Outline Enabled", Float) = 1
+        [MaterialToggle] _ConnectedAlpha ("Connected Alpha", Float) = 0
+        [HideInInspector] _AlphaThreshold ("Alpha clean", Range (0, 1)) = 0
+        _Thickness ("Width (Max recommended 100)", float) = 3
+        [KeywordEnum(Solid, Gradient, Image)] _OutlineMode("Outline mode", Float) = 0
+        [KeywordEnum(Contour, Frame)] _OutlineShape("Outline shape", Float) = 0
+        [KeywordEnum(Inside under sprite, Inside over sprite, Outside)] _OutlinePosition("Outline Position (Frame Only)", Float) = 0
+    }
+
+    SubShader {
+        Tags {
+            "Queue"="Transparent"
+            "IgnoreProjector"="True"
+            "RenderType"="Transparent"
+            "PreviewType"="Plane"
+            "CanUseSpriteAtlas"="True"
+        }
+
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend One OneMinusSrcAlpha
+
+        Pass {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma multi_compile _ PIXELSNAP_ON
+            #pragma exclude_renderers d3d11_9x
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t {
+                float4 vertex : POSITION;
+                float4 color : COLOR;
+                float2 texcoord : TEXCOORD0;
+            };
+
+            struct v2f {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                fixed4 color : COLOR;
+            };
+
+            fixed4 _Color;
+            fixed _Thickness;
+            fixed _OutlineEnabled;
+            fixed _ConnectedAlpha;
+            fixed _OutlineShape;
+            fixed _OutlinePosition;
+            fixed _OutlineMode;
+            fixed4 _OutlineColor;
+            fixed _OutlineSize;
+
+            sampler2D _MainTex;
+            uniform float4 _MainTex_TexelSize;
+
+            v2f vert(appdata_t IN) {
+                v2f OUT;
+                OUT.vertex = UnityObjectToClipPos(IN.vertex);
+                OUT.texcoord = IN.texcoord;
+                OUT.color = IN.color * _Color;
+                #ifdef PIXELSNAP_ON
+                OUT.vertex = UnityPixelSnap(OUT.vertex);
+                #endif
+                return OUT;
+            }
+
+            // UV 좌표를 기반으로 테두리 그리기 로직
+            fixed4 frag(v2f IN) : SV_Target {
+                float2 uv = IN.texcoord;
+                float alpha = 0;
+
+                // 기본 이미지 색상 샘플링
+                fixed4 original = tex2D(_MainTex, uv);
+
+                // 테두리 사이즈만큼 이미지 경계 밖으로 UV를 확장하여 테두리 처리
+                for (float x = -1.0; x <= 1.0; x += 0.5) {
+                    for (float y = -1.0; y <= 1.0; y += 0.5) {
+                        float2 offsetUV = uv + float2(x * _OutlineSize, y * _OutlineSize);
+
+                        // 테두리 처리
+                        fixed4 sample = tex2D(_MainTex, offsetUV);
+                        alpha = max(alpha, sample.a);
+                    }
+                }
+
+                // 테두리가 필요한 경우 테두리 색상 적용
+                if (alpha > 0.1 && original.a < 0.1) {
+                    return _OutlineColor;
+                }
+
+                // 원래 이미지를 출력
+                return original;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Sprites/OutlineMaterial/DoorInteractShader.shader.meta
+++ b/Assets/Sprites/OutlineMaterial/DoorInteractShader.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b63b97bdade5ba24c97dffb6bde722be
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/OutlineMaterial/HighlightState_Door.mat
+++ b/Assets/Sprites/OutlineMaterial/HighlightState_Door.mat
@@ -7,8 +7,8 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: HighlightState
-  m_Shader: {fileID: 4800000, guid: 62505ee61d20098489c6f861ed25cce1, type: 3}
+  m_Name: HighlightState_Door
+  m_Shader: {fileID: 4800000, guid: b63b97bdade5ba24c97dffb6bde722be, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
@@ -17,7 +17,6 @@ Material:
   - _OUTLINEMODE_SOLID
   - _OUTLINEPOSITION_INSIDE_UNDER_SPRITE
   - _OUTLINESHAPE_CONTOUR
-  - _TILEMODE_STRETCH
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -45,10 +44,6 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _EmissionMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _FrameTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -87,12 +82,12 @@ Material:
     - _OutlineMode: 0
     - _OutlinePosition: 0
     - _OutlineShape: 0
+    - _OutlineSize: 0.0267
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _Thickness: 3
-    - _TileMode: 0
     - _UVSec: 0
     - _Weight: 0.5
     - _ZWrite: 1
@@ -101,6 +96,6 @@ Material:
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _GradientOutline1: {r: 1, g: 1, b: 1, a: 1}
     - _GradientOutline2: {r: 1, g: 1, b: 1, a: 1}
-    - _ImageOutline: {r: 1, g: 1, b: 1, a: 1}
+    - _OutlineColor: {r: 1, g: 1, b: 1, a: 1}
     - _SolidOutline: {r: 1, g: 1, b: 1, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Sprites/OutlineMaterial/HighlightState_Door.mat.meta
+++ b/Assets/Sprites/OutlineMaterial/HighlightState_Door.mat.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 789cf6336a550f149a3a82a3787f55fb
+guid: 1a0517ea99bbc3e45bc921cbe1b5dec6
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 2100000

--- a/Assets/Sprites/OutlineMaterial/HighlightState_ElseObject.mat
+++ b/Assets/Sprites/OutlineMaterial/HighlightState_ElseObject.mat
@@ -1,0 +1,106 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HighlightState_ElseObject
+  m_Shader: {fileID: 4800000, guid: 62505ee61d20098489c6f861ed25cce1, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords:
+  - _OUTLINEENABLED_ON
+  - _OUTLINEMODE_SOLID
+  - _OUTLINEPOSITION_INSIDE_UNDER_SPRITE
+  - _OUTLINESHAPE_CONTOUR
+  - _TILEMODE_STRETCH
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _FrameTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaThreshold: 0
+    - _Angle: 45
+    - _BumpScale: 1
+    - _ConnectedAlpha: 0
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _OutlineEnabled: 1
+    - _OutlineMode: 0
+    - _OutlinePosition: 0
+    - _OutlineShape: 0
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Thickness: 3
+    - _TileMode: 0
+    - _UVSec: 0
+    - _Weight: 0.5
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _GradientOutline1: {r: 1, g: 1, b: 1, a: 1}
+    - _GradientOutline2: {r: 1, g: 1, b: 1, a: 1}
+    - _ImageOutline: {r: 1, g: 1, b: 1, a: 1}
+    - _SolidOutline: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Sprites/OutlineMaterial/HighlightState_ElseObject.mat.meta
+++ b/Assets/Sprites/OutlineMaterial/HighlightState_ElseObject.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0e469783926eb7e4baeec88270a07c91
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### 작업 내용

* before
![image](https://github.com/user-attachments/assets/bbc23877-4e45-4b6b-9d26-b5538c52cd9d)

* after
![image](https://github.com/user-attachments/assets/3dcec5b8-61ca-4ca3-8864-4f3d1f1c234a)

* 감옥 문 uv좌표를 원래 임포트해서 사용했던 2d sprite renderer가 제대로 인식하지 못해 테두리가 이상하게 생성되었습니다. 따라서 문 전용 셰이더 스크립트를 따로 작성하여 테두리 깨짐 현상을 방지하였습니다.
* 새로 작성된 셰이더는 곡률같은 정보는 무시한 데다 성능이 좋지 않아 파이프 같은 곳에는 적용할 수 없었습니다. 매끄러운 표면이 있는 문이나 차후 박스? 창문? 같은 매끄러운 오브젝트의 테두리를 위해 적용할 수 있을 것 같습니다.

### 참고사항

* 시행착오가 너무 심했던 데다가 이것저것 속성을 만져본 게 너무 많아서 실수로 커밋했다가 다른 오류가 흘러들어갈까봐 일부러 픽스 성공 후 커밋을 한번에 하였습니다. 대략적인 과정은 트러블슈팅에 정리해 보겠습니다.
* 문 이미지에 양 옆에 투명한 패딩을 붙여 업데이트하였습니다. 프라이빗 리포지토리에 커밋해 뒀으니 풀 하셔야 적용됩니다 :)

### Merge 데드라인
* 10월 16일까지는 확인 부탁드립니다ㅏㅏ