### PR TITLE
[Feature] 퍼즐 중복 로드 방지 / 상호작용 중 플레이어 이동 제한 구현

### DIFF
--- a/Assets/Scenes/PrisonScene.unity
+++ b/Assets/Scenes/PrisonScene.unity
@@ -605,7 +605,7 @@ Transform:
   m_GameObject: {fileID: 443638698}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -11.21, y: 1.79, z: -0.6}
+  m_LocalPosition: {x: 0.31, y: -3.77, z: -0.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -627,6 +627,7 @@ MonoBehaviour:
   inputVec1: {x: 0, y: 0}
   inputVec2: {x: 0, y: 0}
   speed: 3
+  canMove: 1
   playerID: 1
 --- !u!1 &611649856
 GameObject:
@@ -682,7 +683,6 @@ MonoBehaviour:
   hasInteracted: 0
   prisonDust: {fileID: 611649856}
   sr: {fileID: 611649859}
-  dustPuzzle: {fileID: 1673583909}
 --- !u!212 &611649859
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -6305,7 +6305,6 @@ MonoBehaviour:
   hasInteracted: 0
   prisonDust: {fileID: 1020231855}
   sr: {fileID: 1020231858}
-  dustPuzzle: {fileID: 1673583909}
 --- !u!212 &1020231858
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -6647,7 +6646,6 @@ MonoBehaviour:
   hasInteracted: 0
   floodWaterPrefab: {fileID: 4514021233988864339, guid: b9da7948c1f650844843685cc4e87959, type: 3}
   sr: {fileID: 1136572491}
-  pipePuzzle: {fileID: 1673583909}
 --- !u!212 &1136572491
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -6920,7 +6918,6 @@ MonoBehaviour:
   prisonDoor: {fileID: 1264324508}
   doorMoveSpeed: 1
   sr: {fileID: 1264324512}
-  doorPuzzle: {fileID: 1673583909}
 --- !u!60 &1264324511
 PolygonCollider2D:
   m_ObjectHideFlags: 0
@@ -7154,6 +7151,7 @@ MonoBehaviour:
   inputVec1: {x: 0, y: 0}
   inputVec2: {x: 0, y: 0}
   speed: 3
+  canMove: 1
   playerID: 2
 --- !u!50 &1279382549
 Rigidbody2D:
@@ -7278,7 +7276,7 @@ Transform:
   m_GameObject: {fileID: 1279382546}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -5.76, y: 5.18, z: -0.6}
+  m_LocalPosition: {x: 2, y: -3.99, z: -0.6}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -7779,6 +7777,8 @@ MonoBehaviour:
   goalZoneColor: {r: 1, g: 1, b: 1, a: 0.50980395}
   interactionsCompleted: 
   interactCount: 0
+  player1: {fileID: 504270776}
+  player2: {fileID: 1279382548}
   limitTime: 5
   remainTime: 5
   isTimeOver: 0
@@ -7853,7 +7853,6 @@ MonoBehaviour:
   hasInteracted: 0
   prisonDust: {fileID: 1664822651}
   sr: {fileID: 1664822654}
-  dustPuzzle: {fileID: 1673583909}
 --- !u!212 &1664822654
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -8118,7 +8117,6 @@ MonoBehaviour:
   prisonDoor: {fileID: 1722749263}
   doorMoveSpeed: 1
   sr: {fileID: 1722749267}
-  doorPuzzle: {fileID: 1673583909}
 --- !u!60 &1722749266
 PolygonCollider2D:
   m_ObjectHideFlags: 0
@@ -9070,7 +9068,6 @@ MonoBehaviour:
   hasInteracted: 0
   prisonDust: {fileID: 2125304059}
   sr: {fileID: 2125304062}
-  dustPuzzle: {fileID: 1673583909}
 --- !u!212 &2125304062
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -9229,7 +9226,6 @@ MonoBehaviour:
   hasInteracted: 0
   prisonLeaf: {fileID: 2128404430}
   sr: {fileID: 2128404432}
-  leafPuzzle: {fileID: 1673583909}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Script/PrisonInteractScript/DoorInteractScript.cs
+++ b/Assets/Script/PrisonInteractScript/DoorInteractScript.cs
@@ -29,8 +29,6 @@ public class DoorInteract : MonoBehaviour
     private bool isMoving = false;
     // 문을 참조해서 material을 조정하기 위한 spriterenderer 변수
     public SpriteRenderer sr;
-    // 문 퍼즐
-    public GameObject doorPuzzle;
     // 퍼즐이 열려있는지 확인하기 위한 변수
     private bool isPuzzleOpen = false;
 
@@ -95,7 +93,7 @@ public class DoorInteract : MonoBehaviour
         {
             // 씬매니저로 퍼즐씬 불러오기
             SceneManager.LoadScene("PrisonDoorPuzzleScene", LoadSceneMode.Additive);
-            // doorPuzzle 오브젝트 활성화
+            // 퍼즐 오픈 변수 true
             isPuzzleOpen = true;
        }
 

--- a/Assets/Script/PrisonInteractScript/DoorInteractScript.cs
+++ b/Assets/Script/PrisonInteractScript/DoorInteractScript.cs
@@ -14,19 +14,19 @@ public class DoorInteract : MonoBehaviour
     // stagemanager를 참조해서 상호작용 여부를 제어하기 위한 변수
     public StageManager stageManager;
     // 플레이어를 참조해서 위치를 받아오기 위한 변수
-    public Transform playerLocation; 
+    public Transform playerLocation;
     // 상호작용 거리
-    public float interactionDistance = 1.0f; 
+    public float interactionDistance = 1.0f;
     // 상호작용 여부
-    public bool hasInteracted = false; 
+    public bool hasInteracted = false;
     // 문을 참조하기 위한 변수
     public GameObject prisonDoor;
     // 문을 이동시킬 목표 위치 targetPosition 선언
     private Vector3 targetPosition;
     // 문 이동 속도
-    public float doorMoveSpeed = 0.1f; 
+    public float doorMoveSpeed = 0.1f;
     // 문이 이동 중인지 여부
-    private bool isMoving = false; 
+    private bool isMoving = false;
     // 문을 참조해서 material을 조정하기 위한 spriterenderer 변수
     public SpriteRenderer sr;
     // 문 퍼즐
@@ -50,18 +50,18 @@ public class DoorInteract : MonoBehaviour
         float distanceToPlayer = Vector3.Distance(transform.position, playerLocation.position);
 
         // 테두리 생성
-        ShowHighlight(); 
+        ShowHighlight();
 
         // 상호작용 가능한 거리 안에 있고 상호작용하지 않았다면
         if (distanceToPlayer <= interactionDistance && !hasInteracted)
         {
             // 스페이스바로 상호작용
-            if (Input.GetKeyDown(KeyCode.Space)) 
+            if (Input.GetKeyDown(KeyCode.Space))
             {
-                Interact(); 
+                Interact();
             }
         }
-        else 
+        else
         {
             // 테두리 삭제
             HideHighlight();
@@ -72,9 +72,9 @@ public class DoorInteract : MonoBehaviour
             // 오브젝트 상호작용됨
             hasInteracted = true;
             // 퍼즐이 닫힘
-            isPuzzleOpen = false; 
+            isPuzzleOpen = false;
             // 문 열기 시작
-            isMoving = true; 
+            isMoving = true;
             // statemanager에게 상호작용되었다고 알림
             stageManager.ObjectInteract(objectIndex);
             // 퍼즐매니저의 퍼즐 성공여부를 초기화
@@ -90,10 +90,15 @@ public class DoorInteract : MonoBehaviour
     // 상호작용 함수
     void Interact()
     {
-        // 씬매니저로 퍼즐씬 불러오기
-        SceneManager.LoadScene("PrisonDoorPuzzleScene", LoadSceneMode.Additive);
-        // doorPuzzle 오브젝트 활성화
-        isPuzzleOpen = true;
+        // 퍼즐이 열려 있지 않을 때만 Interact가 실행되었을 때 퍼즐씬이 불러와지도록 조건 추가
+        if (!isPuzzleOpen)
+        {
+            // 씬매니저로 퍼즐씬 불러오기
+            SceneManager.LoadScene("PrisonDoorPuzzleScene", LoadSceneMode.Additive);
+            // doorPuzzle 오브젝트 활성화
+            isPuzzleOpen = true;
+       }
+
     }
 
     // 문을 부드럽게 이동시키는 함수

--- a/Assets/Script/PrisonInteractScript/DoorInteractScript.cs
+++ b/Assets/Script/PrisonInteractScript/DoorInteractScript.cs
@@ -77,6 +77,8 @@ public class DoorInteract : MonoBehaviour
             stageManager.ObjectInteract(objectIndex);
             // 퍼즐매니저의 퍼즐 성공여부를 초기화
             PuzzleManager.instance.isPuzzleSuccess = false;
+            // 퍼즐이 성공했으므로 플레이어 이동 가능하게 설정
+            playerLocation.GetComponent<Player>().canMove = true;
         }
         // isMoving이면 문을 이동시키는 애니메이션 함수 작동
         if (isMoving)
@@ -95,6 +97,8 @@ public class DoorInteract : MonoBehaviour
             SceneManager.LoadScene("PrisonDoorPuzzleScene", LoadSceneMode.Additive);
             // 퍼즐 오픈 변수 true
             isPuzzleOpen = true;
+            // Player.cs의 canMove를 제어해 플레이어 이동 제한
+            playerLocation.GetComponent<Player>().canMove = false;
        }
 
     }

--- a/Assets/Script/PrisonInteractScript/DustInteractScript.cs
+++ b/Assets/Script/PrisonInteractScript/DustInteractScript.cs
@@ -64,6 +64,8 @@ public class DustInteract : MonoBehaviour
             stageManager.ObjectInteract(objectIndex);
             // 퍼즐매니저의 퍼즐 성공여부를 초기화
             PuzzleManager.instance.isPuzzleSuccess = false;
+            // 퍼즐이 성공했으므로 플레이어 이동 가능하게 설정
+            playerLocation.GetComponent<Player>().canMove = true;
             // 상호작용 성공 시 먼지 맵에서 삭제
             Destroy(prisonDust);
         }
@@ -79,6 +81,8 @@ public class DustInteract : MonoBehaviour
             SceneManager.LoadScene("PrisonDustPuzzleScene", LoadSceneMode.Additive);
             // 퍼즐 오픈 변수 true
             isPuzzleOpen = true;
+            // Player.cs의 canMove를 제어해 플레이어 이동 제한
+            playerLocation.GetComponent<Player>().canMove = false;
         }
     }
 

--- a/Assets/Script/PrisonInteractScript/DustInteractScript.cs
+++ b/Assets/Script/PrisonInteractScript/DustInteractScript.cs
@@ -14,17 +14,15 @@ public class DustInteract : MonoBehaviour
     // stagemanager를 참조해서 상호작용 여부를 제어하기 위한 변수
     public StageManager stageManager;
     // 플레이어를 참조해서 위치를 받아오기 위한 변수
-    public Transform playerLocation; 
+    public Transform playerLocation;
     // 상호작용 거리
-    public float interactionDistance = 1.0f; 
+    public float interactionDistance = 1.0f;
     // 상호작용 여부
-    public bool hasInteracted = false; 
+    public bool hasInteracted = false;
     // 먼지를 참조하기 위한 변수
     public GameObject prisonDust;
     // 먼지를 참조해서 material을 조정하기 위한 spriterenderer 변수
     public SpriteRenderer sr;
-    // 먼지 퍼즐
-    public GameObject dustPuzzle;
     // 퍼즐이 열려있는지 확인하기 위한 변수
     private bool isPuzzleOpen = false;
 
@@ -39,52 +37,49 @@ public class DustInteract : MonoBehaviour
         float distanceToPlayer = Vector3.Distance(transform.position, playerLocation.position);
 
         // 테두리 생성
-        ShowHighlight(); 
+        ShowHighlight();
 
         // 상호작용 가능한 거리 안에 있고 상호작용하지 않았다면
         if (distanceToPlayer <= interactionDistance && !hasInteracted)
         {
             // 스페이스바로 상호작용
-            if (Input.GetKeyDown(KeyCode.Space)) 
+            if (Input.GetKeyDown(KeyCode.Space))
             {
-                Interact(); 
+                Interact();
             }
         }
-        else 
+        else
         {
             // 테두리 삭제
             HideHighlight();
         }
-        // 퍼즐이 열려 있는 상태에서 Z를 누르면 씬을 닫음
-        if (isPuzzleOpen && Input.GetKeyDown(KeyCode.Z))
+        // 퍼즐이 열려 있을 때 퍼즐을 해결하면 상호작용 성공
+        if (isPuzzleOpen && PuzzleManager.instance.isPuzzleSuccess)
         {
-            CloseCurrentPuzzleScene();
+            // 오브젝트 상호작용됨
+            hasInteracted = true;
+            // 퍼즐이 닫힘
+            isPuzzleOpen = false;
+            // statemanager에게 상호작용되었다고 알림
+            stageManager.ObjectInteract(objectIndex);
+            // 퍼즐매니저의 퍼즐 성공여부를 초기화
+            PuzzleManager.instance.isPuzzleSuccess = false;
+            // 상호작용 성공 시 먼지 맵에서 삭제
+            Destroy(prisonDust);
         }
     }
 
     // 상호작용 함수
     void Interact()
     {
-        // 씬매니저로 퍼즐씬 불러오기
-        SceneManager.LoadScene("PrisonDustPuzzleScene", LoadSceneMode.Additive);
-        // dustPuzzle 오브젝트 활성화
-        if (dustPuzzle != null)
+        // 퍼즐이 열려 있지 않을 때만 Interact가 실행되었을 때 퍼즐씬이 불러와지도록 조건 추가
+        if (!isPuzzleOpen)
         {
-            dustPuzzle.SetActive(true);
+            // 씬매니저로 퍼즐씬 불러오기
+            SceneManager.LoadScene("PrisonDustPuzzleScene", LoadSceneMode.Additive);
+            // 퍼즐 오픈 변수 true
             isPuzzleOpen = true;
         }
-        stageManager.ObjectInteract(objectIndex);
-        HideHighlight(); 
-        Destroy(prisonDust);
-    }
-
-    void CloseCurrentPuzzleScene()
-    {
-        dustPuzzle.SetActive(false);
-        // 퍼즐 닫힘을 표시
-        isPuzzleOpen = false;
-        // 상호작용되었음을 표시
-        hasInteracted = true;
     }
 
     // 테두리 생성 및 표시

--- a/Assets/Script/PrisonInteractScript/LeafInteractScript.cs
+++ b/Assets/Script/PrisonInteractScript/LeafInteractScript.cs
@@ -65,6 +65,8 @@ public class LeafInteract : MonoBehaviour
             stageManager.ObjectInteract(objectIndex);
             // 퍼즐매니저의 퍼즐 성공여부를 초기화
             PuzzleManager.instance.isPuzzleSuccess = false;
+            // 퍼즐이 성공했으므로 플레이어 이동 가능하게 설정
+            playerLocation.GetComponent<Player>().canMove = true;
             // 상호작용 성공 시 낙엽 맵에서 삭제
             Destroy(prisonLeaf);
         }
@@ -79,6 +81,8 @@ public class LeafInteract : MonoBehaviour
             SceneManager.LoadScene("PrisonLeafPuzzleScene", LoadSceneMode.Additive);
             // 퍼즐 오픈 변수 true
             isPuzzleOpen = true;
+            // Player.cs의 canMove를 제어해 플레이어 이동 제한
+            playerLocation.GetComponent<Player>().canMove = false;
         }
     }
 

--- a/Assets/Script/PrisonInteractScript/LeafInteractScript.cs
+++ b/Assets/Script/PrisonInteractScript/LeafInteractScript.cs
@@ -23,8 +23,6 @@ public class LeafInteract : MonoBehaviour
     public GameObject prisonLeaf;
     // 낙엽을 참조해서 material을 조정하기 위한 spriterenderer 변수
     public SpriteRenderer sr;
-    // 나뭇잎 퍼즐
-    public GameObject leafPuzzle;
     // 퍼즐이 열려있는지 확인하기 위한 변수
     private bool isPuzzleOpen = false;
 
@@ -56,35 +54,32 @@ public class LeafInteract : MonoBehaviour
             // 테두리 삭제
             HideHighlight();
         }
-        // 퍼즐이 열려 있는 상태에서 Z를 누르면 씬을 닫음
-        if (isPuzzleOpen && Input.GetKeyDown(KeyCode.Z))
+        // 퍼즐이 열려 있을 때 퍼즐을 해결하면 상호작용 성공
+        if (isPuzzleOpen && PuzzleManager.instance.isPuzzleSuccess)
         {
-            CloseCurrentPuzzleScene();
+            // 오브젝트 상호작용됨
+            hasInteracted = true;
+            // 퍼즐이 닫힘
+            isPuzzleOpen = false;
+            // statemanager에게 상호작용되었다고 알림
+            stageManager.ObjectInteract(objectIndex);
+            // 퍼즐매니저의 퍼즐 성공여부를 초기화
+            PuzzleManager.instance.isPuzzleSuccess = false;
+            // 상호작용 성공 시 낙엽 맵에서 삭제
+            Destroy(prisonLeaf);
         }
     }
 
     void Interact()
     {
-        // 씬매니저로 퍼즐씬 불러오기
-        SceneManager.LoadScene("PrisonLeafPuzzleScene", LoadSceneMode.Additive);
-        // leafPuzzle 오브젝트 활성화
-        if (leafPuzzle != null)
+        // 퍼즐이 열려 있지 않을 때만 Interact가 실행되었을 때 퍼즐씬이 불러와지도록 조건 추가
+        if (!isPuzzleOpen)
         {
-            leafPuzzle.SetActive(true);
+            // 씬매니저로 퍼즐씬 불러오기
+            SceneManager.LoadScene("PrisonLeafPuzzleScene", LoadSceneMode.Additive);
+            // 퍼즐 오픈 변수 true
             isPuzzleOpen = true;
         }
-        stageManager.ObjectInteract(objectIndex);
-        HideHighlight();
-        Destroy(prisonLeaf);
-    }
-
-    void CloseCurrentPuzzleScene()
-    {
-        leafPuzzle.SetActive(false);
-        // 퍼즐 닫힘을 표시
-        isPuzzleOpen = false;
-        // 상호작용되었음을 표시
-        hasInteracted = true;
     }
 
     // 테두리 생성 및 표시

--- a/Assets/Script/PrisonInteractScript/PipeInteractScript.cs
+++ b/Assets/Script/PrisonInteractScript/PipeInteractScript.cs
@@ -66,6 +66,8 @@ public class PipeInteract : MonoBehaviour
             stageManager.ObjectInteract(objectIndex);
             // 퍼즐매니저의 퍼즐 성공여부를 초기화
             PuzzleManager.instance.isPuzzleSuccess = false;
+            // 퍼즐이 성공했으므로 플레이어 이동 가능하게 설정
+            stageManager.SetPlayerMovement(true);
             // 상호작용 성공 시 물 숨기기
             Destroy(floodWaterInstance);
         }
@@ -81,6 +83,8 @@ public class PipeInteract : MonoBehaviour
             SceneManager.LoadScene("PrisonPipePuzzleScene", LoadSceneMode.Additive);
             // 퍼즐 오픈 변수 true
             isPuzzleOpen = true;
+            // 상호작용해서 퍼즐이 열리면 플레이어 1,2 둘 다 이동 제한
+            stageManager.SetPlayerMovement(false);
         }
     }
 

--- a/Assets/Script/PrisonInteractScript/PipeInteractScript.cs
+++ b/Assets/Script/PrisonInteractScript/PipeInteractScript.cs
@@ -23,8 +23,6 @@ public class PipeInteract : MonoBehaviour
     private GameObject floodWaterInstance; 
     // 파이프를 참조해서 material을 조정하기 위한 spriterenderer 변수
     public SpriteRenderer sr;
-    // 파이프 퍼즐
-    public GameObject pipePuzzle;
     // 퍼즐이 열려있는지 확인하기 위한 변수
     private bool isPuzzleOpen = false;
 
@@ -38,6 +36,7 @@ public class PipeInteract : MonoBehaviour
         // start 혹은 awake에서 sr을 getcomponent 메서드로 초기화
         sr = GetComponent<SpriteRenderer>();
     }
+    
     void Update()
     {
         // 상호작용 존 안에 두 플레이어 모두가 있고 상호작용하지 않았다면
@@ -56,37 +55,33 @@ public class PipeInteract : MonoBehaviour
             // 테두리 삭제
             HideHighlight();
         }
-        // 퍼즐이 열려 있는 상태에서 Z를 누르면 씬을 닫음
-        if (isPuzzleOpen && Input.GetKeyDown(KeyCode.Z))
+        // 퍼즐이 열려 있을 때 퍼즐을 해결하면 상호작용 성공
+        if (isPuzzleOpen && PuzzleManager.instance.isPuzzleSuccess)
         {
-            CloseCurrentPuzzleScene();
+            // 오브젝트 상호작용됨
+            hasInteracted = true;
+            // 퍼즐이 닫힘
+            isPuzzleOpen = false;
+            // statemanager에게 상호작용되었다고 알림
+            stageManager.ObjectInteract(objectIndex);
+            // 퍼즐매니저의 퍼즐 성공여부를 초기화
+            PuzzleManager.instance.isPuzzleSuccess = false;
+            // 상호작용 성공 시 물 숨기기
+            Destroy(floodWaterInstance);
         }
     }
 
     // 상호작용 함수
     void Interact()
     {
-        // 씬매니저로 퍼즐씬 불러오기
-        SceneManager.LoadScene("PrisonPipePuzzleScene", LoadSceneMode.Additive);
-        // pipePuzzle 오브젝트 활성화
-        if (pipePuzzle != null)
+        // 퍼즐이 열려 있지 않을 때만 Interact가 실행되었을 때 퍼즐씬이 불러와지도록 조건 추가
+        if (!isPuzzleOpen)
         {
-            pipePuzzle.SetActive(true);
+            // 씬매니저로 퍼즐씬 불러오기
+            SceneManager.LoadScene("PrisonPipePuzzleScene", LoadSceneMode.Additive);
+            // 퍼즐 오픈 변수 true
             isPuzzleOpen = true;
         }
-        stageManager.ObjectInteract(objectIndex);
-        HideHighlight();
-        // 물 숨기기
-        Destroy(floodWaterInstance);
-    }
-
-    void CloseCurrentPuzzleScene()
-    {
-        pipePuzzle.SetActive(false);
-        // 퍼즐 닫힘을 표시
-        isPuzzleOpen = false;
-        // 상호작용되었음을 표시
-        hasInteracted = true;
     }
 
     // 테두리 생성 및 표시

--- a/Assets/Script/StageManagerScript.cs
+++ b/Assets/Script/StageManagerScript.cs
@@ -19,6 +19,9 @@ public class StageManager : MonoBehaviour
     public bool[] interactionsCompleted;
     // 상호작용 완료된 오브젝트 개수
     public int interactCount = 0;
+    // 플레이어를 관리하는 변수 추가
+    public Player player1;
+    public Player player2;
 
     // 타이머 관련 변수
     // 주어진 시간 - Inspector에서 설정 가능
@@ -107,6 +110,19 @@ public class StageManager : MonoBehaviour
                 // 도착지점 활성화
                 ActiveGoalZone();
             }
+        }
+    }
+
+    // 2인용 퍼즐에 상호작용했을 때, 두 플레이어 모두 이동을 제한하는 메서드
+    public void SetPlayerMovement(bool setcanMove)
+    {
+        if (player1 != null) 
+        {
+            player1.canMove = setcanMove;
+        }
+        if (player2 != null) 
+        {
+            player2.canMove = setcanMove;
         }
     }
 

--- a/Assets/Script/player.cs
+++ b/Assets/Script/player.cs
@@ -10,9 +10,11 @@ public class Player : MonoBehaviour
 	// 플레이어2의 입력 방향을 저장하는 벡터
 	public Vector2 inputVec2;
 
-
 	// 플레이어의 이동 속도
 	public float speed;
+
+	// 플레이어가 이동 가능한지를 제어하는 변수
+	public bool canMove = true;
 		
 	// Rigidbody2D 변수 선언
 	Rigidbody2D rigid;
@@ -60,6 +62,13 @@ public class Player : MonoBehaviour
     	// 물리적 이동은 여기서 처리하는 것이 적합하다.
 	void FixedUpdate()
 	{
+		// 만약 canMove가 false라면
+		if(!canMove)
+		{
+			// 이동 금지
+			return;
+		}
+		
 		Vector2 nextVec = Vector2.zero;	
 		if(playerID == 1)
 		{


### PR DESCRIPTION
### Before
https://github.com/user-attachments/assets/620b978d-0319-470a-be40-95e2fc9bcfbe

### After

https://github.com/user-attachments/assets/cb71b946-8abe-4190-8d44-0fad590b9810


### 작업 내용
* 퍼즐 씬을 열었을 때 상호작용 키를 누르면 중복되게 퍼즐 씬을 불러올 수 있었던 기존 로직을 수정하였습니다.
* 퍼즐 씬을 열었을 때 플레이어의 이동을 금지하기 위해 기존 로직을 수정하였습니다.
  * player.cs에 canMove 변수를 추가했고, 이 canMove가 false일 때 플레이어가 움직일 수 없도록 FixedUpdate()를 수정하였습니다.
  * 문, 먼지, 낙엽 상호작용 스크립트에 있던 playerLocation 변수를 통해 플레이어 오브젝트를 역추적해서 canMove를 제어하도록 구현했습니다.
  * 파이프 상호작용에 대한 플레이어 이동제한은 StageManagerScript.cs에 SetPlayerMovement 함수를 작성해서 구현했습니다.
* DoorInteractScript의 구조를 다른 InteractScript들에도 적용하였습니다.

### Merge 데드라인
* 가급적이면 28일 회의 전까지는 부탁드리겠습니당

### 다음 작업
* 자물쇠 퍼즐 디테일 작업 마무리 (오답 열쇠 타임아웃, 타임아웃에 대한 UI 추가 등)