### PR TITLE
[Fix] 룸 온라인 기능 픽스 / 구현

### DIFF
--- a/Assets/Scenes/RoomScene.unity
+++ b/Assets/Scenes/RoomScene.unity
@@ -1391,7 +1391,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 0}
         m_TargetAssemblyTypeName: NetworkingManager, Assembly-CSharp
-        m_MethodName: SwitchPlayers
+        m_MethodName: 
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1737,7 +1737,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1710354786}
         m_TargetAssemblyTypeName: RoomManager, Assembly-CSharp
-        m_MethodName: ReadyUp
+        m_MethodName: ReadyUpPlayer2
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1827,6 +1827,8 @@ MonoBehaviour:
   player2Indicator: {fileID: 1912108533}
   player1ReadyText: {fileID: 187048803}
   player2ReadyText: {fileID: 345217155}
+  player1ReadyButton: {fileID: 1956269874}
+  player2ReadyButton: {fileID: 1528054315}
 --- !u!4 &1710354787
 Transform:
   m_ObjectHideFlags: 0
@@ -2296,7 +2298,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1710354786}
         m_TargetAssemblyTypeName: RoomManager, Assembly-CSharp
-        m_MethodName: ReadyUp
+        m_MethodName: ReadyUpPlayer1
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scenes/RoomScene.unity
+++ b/Assets/Scenes/RoomScene.unity
@@ -1817,8 +1817,8 @@ MonoBehaviour:
   roomCodeText: {fileID: 260297526}
   daveImage: {fileID: 1494266184}
   matthewImage: {fileID: 1092640913}
-  daveBWImage: {fileID: 21300000, guid: db1ab3213814a984a901e8b233b6cbaa, type: 3}
-  matthewBWImage: {fileID: 21300000, guid: 7869cc5ff7aaee14ca1953f136f02c4c, type: 3}
+  daveBWImage: {fileID: 21300000, guid: 580504e1072455749b0ffb1a199e243d, type: 3}
+  matthewBWImage: {fileID: 21300000, guid: 124a58340e9514b42a29a9d4fe30b52e, type: 3}
   daveColorImage: {fileID: 21300000, guid: 1c2a50f127c5127499e2eb2acdee2e6c, type: 3}
   matthewColorImage: {fileID: 21300000, guid: 4a9f930dda97db140af3793d597f93f3, type: 3}
   daveText: {fileID: 884843663}

--- a/Assets/Scenes/RoomScene.unity
+++ b/Assets/Scenes/RoomScene.unity
@@ -1737,7 +1737,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1710354786}
         m_TargetAssemblyTypeName: RoomManager, Assembly-CSharp
-        m_MethodName: ReadyUpPlayer2
+        m_MethodName: ReadyUpMatthew
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -1815,20 +1815,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   roomCodeText: {fileID: 260297526}
-  player1Image: {fileID: 1494266184}
-  player2Image: {fileID: 1092640913}
-  daveBWImage: {fileID: 21300000, guid: 580504e1072455749b0ffb1a199e243d, type: 3}
-  matthewBWImage: {fileID: 21300000, guid: 124a58340e9514b42a29a9d4fe30b52e, type: 3}
+  daveImage: {fileID: 1494266184}
+  matthewImage: {fileID: 1092640913}
+  daveBWImage: {fileID: 21300000, guid: db1ab3213814a984a901e8b233b6cbaa, type: 3}
+  matthewBWImage: {fileID: 21300000, guid: 7869cc5ff7aaee14ca1953f136f02c4c, type: 3}
   daveColorImage: {fileID: 21300000, guid: 1c2a50f127c5127499e2eb2acdee2e6c, type: 3}
   matthewColorImage: {fileID: 21300000, guid: 4a9f930dda97db140af3793d597f93f3, type: 3}
-  player1Text: {fileID: 884843663}
-  player2Text: {fileID: 370826063}
-  player1Indicator: {fileID: 119636156}
-  player2Indicator: {fileID: 1912108533}
-  player1ReadyText: {fileID: 187048803}
-  player2ReadyText: {fileID: 345217155}
-  player1ReadyButton: {fileID: 1956269874}
-  player2ReadyButton: {fileID: 1528054315}
+  daveText: {fileID: 884843663}
+  matthewText: {fileID: 370826063}
+  daveIndicator: {fileID: 119636156}
+  matthewIndicator: {fileID: 1912108533}
+  daveReadyText: {fileID: 187048803}
+  matthewReadyText: {fileID: 345217155}
+  daveReadyButton: {fileID: 1956269874}
+  matthewReadyButton: {fileID: 1528054315}
+  daveReady: 0
+  matthewReady: 0
 --- !u!4 &1710354787
 Transform:
   m_ObjectHideFlags: 0
@@ -2298,7 +2300,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1710354786}
         m_TargetAssemblyTypeName: RoomManager, Assembly-CSharp
-        m_MethodName: ReadyUpPlayer1
+        m_MethodName: ReadyUpDave
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scenes/RoomScene.unity
+++ b/Assets/Scenes/RoomScene.unity
@@ -404,7 +404,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Ready
+  m_Text: Not Ready
 --- !u!222 &187048804
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -562,7 +562,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: Ready
+  m_Text: Not Ready
 --- !u!222 &345217156
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Script/NetworkingManager.cs
+++ b/Assets/Script/NetworkingManager.cs
@@ -39,6 +39,15 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
         }
     }
 
+    void Update()
+    {
+        if(Input.GetKeyDown(KeyCode.Space))
+        {
+            int playerCount = PhotonNetwork.CountOfPlayers;
+            Debug.Log("현재 로비에 접속된 플레이어 수: " + playerCount);
+        }
+    }
+
 
     // Photon 서버에 연결하는 함수
     public void ConnectToPhotonServer()

--- a/Assets/Script/NetworkingManager.cs
+++ b/Assets/Script/NetworkingManager.cs
@@ -11,7 +11,7 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
 
     // 게임 버전 설정
     private string gameVersion = "1";
-    
+
     // 기존 방 코드를 저장할 HashSet
     private HashSet<string> existingRoomCodes = new HashSet<string>();
 
@@ -31,13 +31,13 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
     }
 
     private void Start()
-{
-    // Photon 서버에 연결된 상태가 아닌 경우에만 연결 시도
-    if (!PhotonNetwork.IsConnected)
     {
-        ConnectToPhotonServer();
+        // Photon 서버에 연결된 상태가 아닌 경우에만 연결 시도
+        if (!PhotonNetwork.IsConnected)
+        {
+            ConnectToPhotonServer();
+        }
     }
-}
 
 
     // Photon 서버에 연결하는 함수
@@ -69,12 +69,12 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
     public void OnExitButtonClicked()
     {
         // 에디터와 프로그램 실행을 구분.
-        #if UNITY_EDITOR
-            UnityEditor.EditorApplication.isPlaying = false;
-        #else
+#if UNITY_EDITOR
+        UnityEditor.EditorApplication.isPlaying = false;
+#else
             // 어플리케이션 종료
             Application.Quit();
-        #endif
+#endif
         Debug.Log("게임 종료");
     }
 
@@ -89,7 +89,7 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
         } while (existingRoomCodes.Contains(roomCode));
 
         // 생성된 코드는 여기 저장
-        existingRoomCodes.Add(roomCode); 
+        existingRoomCodes.Add(roomCode);
         return roomCode;
     }
 
@@ -142,9 +142,11 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
 
         ExitGames.Client.Photon.Hashtable playerProps = new ExitGames.Client.Photon.Hashtable();
         playerProps.Add("Character", assignedCharacter);
+        playerProps.Add("Ready", false);
         player.SetCustomProperties(playerProps);
 
         Debug.Log(player.NickName + "에게 캐릭터 " + assignedCharacter + "가 할당되었습니다.");
+        //Debug.Log("초기 레디값은" + ((bool)player.CustomProperties["Ready"] ? "true" : "false") + "입니다");
     }
 
     // 로비에 접속 성공 시 호출
@@ -205,48 +207,45 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
     // 플레이어 전환을 처리하는 함수
     public void SwitchPlayers()
     {
-        // 로컬 플레이어의 캐릭터 속성 가져오기
         var localPlayer = PhotonNetwork.LocalPlayer;
-        string currentCharacter = localPlayer.CustomProperties.ContainsKey("Character")
-                                ? localPlayer.CustomProperties["Character"].ToString() : "";
+        string localCharacter = localPlayer.CustomProperties["Character"].ToString();
 
-        // 상대 플레이어 찾기
         Photon.Realtime.Player otherPlayer = null;
         foreach (var player in PhotonNetwork.PlayerList)
         {
-            if (!player.IsLocal) // 로컬 플레이어가 아닌 상대 플레이어 찾기
+            if (!player.IsLocal)
             {
                 otherPlayer = player;
                 break;
             }
         }
 
-        // 전환할 상대 플레이어가 없으면 리턴
         if (otherPlayer == null) return;
 
-        // 상대 플레이어의 캐릭터 속성 가져오기
-        string otherCharacter = otherPlayer.CustomProperties.ContainsKey("Character")
-                                ? otherPlayer.CustomProperties["Character"].ToString() : "";
+        string otherCharacter = otherPlayer.CustomProperties["Character"].ToString();
 
-        // 로컬 플레이어와 상대 플레이어의 캐릭터 교환
-        if (!string.IsNullOrEmpty(currentCharacter) && !string.IsNullOrEmpty(otherCharacter))
+        ExitGames.Client.Photon.Hashtable localPlayerProperties = new ExitGames.Client.Photon.Hashtable
+    {
+        { "Character", otherCharacter },
+    };
+        localPlayer.SetCustomProperties(localPlayerProperties);
+
+        ExitGames.Client.Photon.Hashtable otherPlayerProperties = new ExitGames.Client.Photon.Hashtable
+    {
+        { "Character", localCharacter },
+    };
+        otherPlayer.SetCustomProperties(otherPlayerProperties);
+
+        // UI에 Ready 상태 즉시 반영
+        RoomManager roomManager = FindObjectOfType<RoomManager>();
+        if (roomManager != null)
         {
-            // 로컬 플레이어는 상대의 캐릭터를, 상대는 로컬의 캐릭터를 할당
-            // System.Collections.Hashtable과 충돌 여지가 있어서 네임스페이스를 명시적으로 사용했습니다.
-            ExitGames.Client.Photon.Hashtable localPlayerProperties = new ExitGames.Client.Photon.Hashtable { { "Character", otherCharacter } };
-            ExitGames.Client.Photon.Hashtable otherPlayerProperties = new ExitGames.Client.Photon.Hashtable { { "Character", currentCharacter } };
-
-            localPlayer.SetCustomProperties(localPlayerProperties);
-            otherPlayer.SetCustomProperties(otherPlayerProperties);
-
-            Debug.Log($"플레이어 전환 완료: localPlayer는 {otherCharacter}, OnlinePlayer는 {currentCharacter}");
-
-            // 추가: 캐릭터 전환 후 RoomManager의 캐릭터 이미지 업데이트 호출
-            RoomManager roomManager = FindObjectOfType<RoomManager>();
-            if (roomManager != null)
-            {
-                roomManager.UpdateCharacterImages();
-            }
+            roomManager.UpdateCharacterImages();
         }
     }
+
+
+
+
+
 }

--- a/Assets/Script/NetworkingManager.cs
+++ b/Assets/Script/NetworkingManager.cs
@@ -31,10 +31,14 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
     }
 
     private void Start()
+{
+    // Photon 서버에 연결된 상태가 아닌 경우에만 연결 시도
+    if (!PhotonNetwork.IsConnected)
     {
-        // 게임 시작 시 서버 연결
         ConnectToPhotonServer();
     }
+}
+
 
     // Photon 서버에 연결하는 함수
     public void ConnectToPhotonServer()

--- a/Assets/Script/RoomManager.cs
+++ b/Assets/Script/RoomManager.cs
@@ -311,9 +311,6 @@ public class RoomManager : MonoBehaviourPunCallbacks
                 }
             }
             remainingPlayer.SetCustomProperties(newProperties);
-
-            // 매튜를 흑백처리
-            matthewImage.sprite = matthewBWImage;
             // You 
             UpdatePlayerIndicator();
             // 버튼 조작권한
@@ -323,6 +320,8 @@ public class RoomManager : MonoBehaviourPunCallbacks
                 daveReadyText.text = (bool)PhotonNetwork.LocalPlayer.CustomProperties["Ready"] ? "Ready!" : "";
             }
         }
+        // 매튜를 흑백처리
+        matthewImage.sprite = matthewBWImage;
     }
 
     // Back 버튼 클릭 시 호출되는 함수

--- a/Assets/Script/RoomManager.cs
+++ b/Assets/Script/RoomManager.cs
@@ -196,10 +196,21 @@ public class RoomManager : MonoBehaviourPunCallbacks
 
         if (changedProps.ContainsKey("Ready"))
         {
+            bool isReady = (bool)targetPlayer.CustomProperties["Ready"];
+            if (targetPlayer.CustomProperties["Character"].ToString() == "Dave")
+            {
+                player1ReadyText.text = isReady ? "Ready!" : "Not Ready";
+            }
+            else if (targetPlayer.CustomProperties["Character"].ToString() == "Matthew")
+            {
+                player2ReadyText.text = isReady ? "Ready!" : "Not Ready";
+            }
             CheckAllPlayersReady();
         }
         // 캐릭터 속성이 변경되었을 때 이미지 업데이트
         UpdateCharacterImages();
+
+
     }
 
     // 플레이어의 캐릭터 속성에 따라 이미지를 업데이트하는 함수
@@ -301,16 +312,17 @@ public class RoomManager : MonoBehaviourPunCallbacks
                 }
             }
             remainingPlayer.SetCustomProperties(newProperties);
-        }
-        // 매튜를 흑백처리
-        player2Image.sprite = matthewBWImage;
-        // You 
-        UpdatePlayerIndicator();
-        // 버튼 조작권한
-        SetReadyButtonInteractivity();
-        if(PhotonNetwork.LocalPlayer.CustomProperties.ContainsKey("Ready"))
-        {
-            player1ReadyText.text = (bool)PhotonNetwork.LocalPlayer.CustomProperties["Ready"] ? "Ready!" : "";
+
+            // 매튜를 흑백처리
+            player2Image.sprite = matthewBWImage;
+            // You 
+            UpdatePlayerIndicator();
+            // 버튼 조작권한
+            SetReadyButtonInteractivity();
+            if(PhotonNetwork.LocalPlayer.CustomProperties.ContainsKey("Ready"))
+            {
+                player1ReadyText.text = (bool)PhotonNetwork.LocalPlayer.CustomProperties["Ready"] ? "Ready!" : "";
+            }
         }
     }
 

--- a/Assets/Script/RoomManager.cs
+++ b/Assets/Script/RoomManager.cs
@@ -12,8 +12,8 @@ public class RoomManager : MonoBehaviourPunCallbacks
     public Text roomCodeText;
 
     // 플레이어 슬롯을 위한 변수
-    public Image player1Image;
-    public Image player2Image;
+    public Image daveImage;
+    public Image matthewImage;
 
     // 흑백 이미지
     public Sprite daveBWImage;
@@ -24,24 +24,24 @@ public class RoomManager : MonoBehaviourPunCallbacks
     public Sprite matthewColorImage;
 
     // 플레이어 텍스트
-    public Text player1Text;
-    public Text player2Text;
+    public Text daveText;
+    public Text matthewText;
 
     // "You" 텍스트를 위한 변수
-    public Text player1Indicator;
-    public Text player2Indicator;
+    public Text daveIndicator;
+    public Text matthewIndicator;
 
     // 레디 상태 표시 텍스트
-    public Text player1ReadyText;
-    public Text player2ReadyText;
+    public Text daveReadyText;
+    public Text matthewReadyText;
 
     // 레디 버튼
-    public Button player1ReadyButton;
-    public Button player2ReadyButton;
+    public Button daveReadyButton;
+    public Button matthewReadyButton;
 
     // 준비 상태
-    private bool player1Ready = false;
-    private bool player2Ready = false;
+    public bool daveReady = false;
+    public bool matthewReady = false;
 
     // 게임 시작 코루틴
     private Coroutine startGameCoroutine;
@@ -57,18 +57,33 @@ public class RoomManager : MonoBehaviourPunCallbacks
             }
 
             // 초기 텍스트 설정
-            player1Text.text = "플레이어를 기다리는 중...";
-            player2Text.text = "플레이어를 기다리는 중...";
+            daveText.text = "플레이어를 기다리는 중...";
+            matthewText.text = "플레이어를 기다리는 중...";
 
             // 방에 입장 시 초기 이미지 설정
-            player1Image.sprite = daveBWImage;
-            player2Image.sprite = matthewBWImage;
+            daveImage.sprite = daveBWImage;
+            matthewImage.sprite = matthewBWImage;
 
             // 캐릭터 이미지 업데이트
             UpdateCharacterImages();
 
             // 플레이어별로 버튼 접근 권한 설정
-            SetReadyButtonInteractivity();
+            // SetReadyButtonInteractivity();
+        }
+    }
+
+    void Update()
+    {
+        if(Input.GetKeyDown(KeyCode.Space))
+        {
+            foreach (Photon.Realtime.Player player in PhotonNetwork.PlayerList)
+            {
+                if(player.IsLocal)
+                {
+                        Debug.Log("할당 값 : 캐릭터에는 " + (string)player.CustomProperties["Character"]);
+                        Debug.Log("할당 값 : 레디에는 " + ((bool)player.CustomProperties["Ready"] ? "true" : "false"));
+                }
+            }
         }
     }
 
@@ -118,11 +133,11 @@ public class RoomManager : MonoBehaviourPunCallbacks
     private IEnumerator StartGameAfterDelay(float delay)
     {
         float checkTime = 0f;
-        while(checkTime < delay)
+        while (checkTime < delay)
         {
-            foreach(Photon.Realtime.Player player in PhotonNetwork.PlayerList)
+            foreach (Photon.Realtime.Player player in PhotonNetwork.PlayerList)
             {
-                if(!player.CustomProperties.ContainsKey("Ready") || !(bool)player.CustomProperties["Ready"])
+                if (!player.CustomProperties.ContainsKey("Ready") || !(bool)player.CustomProperties["Ready"])
                 {
                     yield break;
                 }
@@ -133,59 +148,36 @@ public class RoomManager : MonoBehaviourPunCallbacks
         SceneManager.LoadScene("PrisonScene");
     }
 
-    public void ReadyUpPlayer1()
+    public void ReadyUpDave()
     {
         if (PhotonNetwork.LocalPlayer.CustomProperties.ContainsKey("Character") && PhotonNetwork.LocalPlayer.CustomProperties["Character"].ToString() == "Dave")
         {
-            // Player1의 준비 상태 전환
-            player1Ready = !player1Ready;
-            player1ReadyText.text = player1Ready ? "Ready!" : "Not Ready";
+            // Dave의 준비 상태 전환
+            daveReady = !daveReady;
+            daveReadyText.text = daveReady ? "Ready!" : "Not Ready";
 
-            // Player1의 준비 상태를 네트워크에 동기화
-            PhotonNetwork.LocalPlayer.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { { "Ready", player1Ready } });
+            // Dave의 준비 상태를 네트워크에 동기화
+            PhotonNetwork.LocalPlayer.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { { "Ready", daveReady } });
 
             // 모든 플레이어가 준비됐는지 확인
             CheckAllPlayersReady();
         }
     }
 
-    public void ReadyUpPlayer2()
+    public void ReadyUpMatthew()
     {
         if (PhotonNetwork.LocalPlayer.CustomProperties.ContainsKey("Character") && PhotonNetwork.LocalPlayer.CustomProperties["Character"].ToString() == "Matthew")
         {
-            // Player2의 준비 상태 전환
-            player2Ready = !player2Ready;
-            player2ReadyText.text = player2Ready ? "Ready!" : "Not Ready";
+            // matthew의 준비 상태 전환
+            matthewReady = !matthewReady;
+            matthewReadyText.text = matthewReady ? "Ready!" : "Not Ready";
 
-            // Player2의 준비 상태를 네트워크에 동기화
-            PhotonNetwork.LocalPlayer.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { { "Ready", player2Ready } });
+            
+            // matthew의 준비 상태를 네트워크에 동기화
+            PhotonNetwork.LocalPlayer.SetCustomProperties(new ExitGames.Client.Photon.Hashtable { { "Ready", matthewReady } });
 
             // 모든 플레이어가 준비됐는지 확인
             CheckAllPlayersReady();
-        }
-    }
-
-    // 플레이어별 레디 버튼을 자신의 캐릭터에 맞게 활성화 또는 비활성화
-    private void SetReadyButtonInteractivity()
-    {
-        foreach (Photon.Realtime.Player player in PhotonNetwork.PlayerList)
-        {
-            if (player.CustomProperties.ContainsKey("Character"))
-            {
-                string character = player.CustomProperties["Character"].ToString();
-                if(player.IsLocal)
-                {
-                    if (character == "Dave")
-                    {
-                        player1ReadyButton.interactable = true;
-                        player2ReadyButton.interactable = false;
-                    }
-                    else if(character == "Matthew"){
-                        player1ReadyButton.interactable = false;
-                        player2ReadyButton.interactable = true;
-                    }
-                }
-            }
         }
     }
 
@@ -196,14 +188,17 @@ public class RoomManager : MonoBehaviourPunCallbacks
 
         if (changedProps.ContainsKey("Ready"))
         {
+            Debug.Log("레디 변경 감지 작동");
             bool isReady = (bool)targetPlayer.CustomProperties["Ready"];
             if (targetPlayer.CustomProperties["Character"].ToString() == "Dave")
             {
-                player1ReadyText.text = isReady ? "Ready!" : "Not Ready";
+                Debug.Log(targetPlayer.CustomProperties["Character"].ToString() + "의 상태는 " + (isReady ? "Ready!" : "Not Ready"));
+                daveReadyText.text = isReady ? "Ready!" : "Not Ready";
             }
             else if (targetPlayer.CustomProperties["Character"].ToString() == "Matthew")
             {
-                player2ReadyText.text = isReady ? "Ready!" : "Not Ready";
+                Debug.Log(targetPlayer.CustomProperties["Character"].ToString() + "의 상태는 " + (isReady ? "Ready!" : "Not Ready"));
+                matthewReadyText.text = isReady ? "Ready!" : "Not Ready";
             }
             CheckAllPlayersReady();
         }
@@ -213,39 +208,60 @@ public class RoomManager : MonoBehaviourPunCallbacks
 
     }
 
-    // 플레이어의 캐릭터 속성에 따라 이미지를 업데이트하는 함수
+
     public void UpdateCharacterImages()
+{
+    // Dave와 Matthew의 캐릭터 속성을 확인하여 정보 업데이트
+    foreach (Photon.Realtime.Player player in PhotonNetwork.PlayerList)
     {
-        // Player1과 Player2의 캐릭터 속성을 확인하여 정보 업데이트
-        foreach (Photon.Realtime.Player player in PhotonNetwork.PlayerList)
+        if (player.CustomProperties.ContainsKey("Character"))
         {
-            if (player.CustomProperties.ContainsKey("Character"))
+            string character = player.CustomProperties["Character"].ToString();
+            if (character == "Dave")
             {
-                string character = player.CustomProperties["Character"].ToString();
-                if (character == "Dave")
+                // Dave가 룸에 있을 경우 이미지 컬러로 변경 및 텍스트 업데이트
+                daveImage.sprite = daveColorImage;
+                daveText.text = "Player1";
+                if (player.IsLocal)
                 {
-                    // Player1이 Dave일 경우 이미지 컬러로 변경 및 텍스트 업데이트
-                    player1Image.sprite = daveColorImage;
-                    player1Text.text = "Player1";
-                    player1ReadyText.text = player1Ready ? "Ready!" : "Not Ready";
-                    player1Indicator.text = player.IsLocal ? "You" : "";
+                    daveReadyButton.interactable = true;
+                    matthewReadyButton.interactable = false;
                 }
-                else if (character == "Matthew")
+
+                // 레디 상태 업데이트
+                if (player.CustomProperties.ContainsKey("Ready"))
                 {
-                    // Player2가 Matthew일 경우 이미지 컬러로 변경 및 텍스트 업데이트
-                    player2Image.sprite = matthewColorImage;
-                    player2Text.text = "Player2";
-                    player2ReadyText.text = player2Ready ? "Ready!" : "Not Ready";
-                    player2Indicator.text = player.IsLocal ? "You" : "";
+                    bool isReady = (bool)player.CustomProperties["Ready"];
+                    daveReadyText.text = isReady ? "Ready!" : "Not Ready";
+                }
+            }
+            else if (character == "Matthew")
+            {
+                // Matthew가 룸에 있을 경우 이미지 컬러로 변경 및 텍스트 업데이트
+                matthewImage.sprite = matthewColorImage;
+                matthewText.text = "Player2";
+                if (player.IsLocal)
+                {
+                    daveReadyButton.interactable = false;
+                    matthewReadyButton.interactable = true;
+                }
+
+                // 레디 상태 업데이트
+                if (player.CustomProperties.ContainsKey("Ready"))
+                {
+                    bool isReady = (bool)player.CustomProperties["Ready"];
+                    matthewReadyText.text = isReady ? "Ready!" : "Not Ready";
                 }
             }
         }
-
-        // 추가: 만약 스위칭 로직에서 호출되면 즉시 "You" 텍스트 업데이트
-        UpdatePlayerIndicator();
     }
 
-    private void UpdatePlayerIndicator()
+    // 추가: 만약 스위칭 로직에서 호출되면 즉시 "You" 텍스트 업데이트
+    UpdatePlayerIndicator();
+}
+
+
+    public void UpdatePlayerIndicator()
     {
         // 플레이어 전환 시 "You" 텍스트를 알맞게 업데이트
         foreach (Photon.Realtime.Player player in PhotonNetwork.PlayerList)
@@ -257,35 +273,18 @@ public class RoomManager : MonoBehaviourPunCallbacks
                 {
                     if (character == "Dave")
                     {
-                        player1Indicator.text = "You";
-                        player2Indicator.text = "";
+                        daveIndicator.text = "You";
+                        matthewIndicator.text = "";
                     }
                     else if (character == "Matthew")
                     {
-                        player1Indicator.text = "";
-                        player2Indicator.text = "You";
+                        daveIndicator.text = "";
+                        matthewIndicator.text = "You";
                     }
                 }
+                
             }
         }
-    }
-
-    // 방을 나간 플레이어의 캐릭터 이미지를 흑백으로 변경하는 메서드
-    private void SetCharacterImagesToBlackAndWhite()
-    {
-        foreach (var player in PhotonNetwork.PlayerList)
-        {
-            if (player.CustomProperties.ContainsKey("Character"))
-            {
-                string character = player.CustomProperties["Character"].ToString();
-
-                if (character == "Matthew")
-                {
-                    return;
-                }
-            }
-        }
-        player2Image.sprite = matthewBWImage;
     }
 
     // 플레이어가 방에서 나갈 때 호출
@@ -294,7 +293,7 @@ public class RoomManager : MonoBehaviourPunCallbacks
         if (otherPlayer.CustomProperties["Character"].ToString() == "Dave")
         {
             Photon.Realtime.Player remainingPlayer;
-            if(PhotonNetwork.PlayerList[0] == otherPlayer)
+            if (PhotonNetwork.PlayerList[0] == otherPlayer)
             {
                 remainingPlayer = PhotonNetwork.PlayerList[1];
             }
@@ -306,7 +305,7 @@ public class RoomManager : MonoBehaviourPunCallbacks
             var newProperties = new ExitGames.Client.Photon.Hashtable();
             foreach (var key in otherPlayer.CustomProperties.Keys)
             {
-                if(remainingPlayer.CustomProperties.ContainsKey(key))
+                if (remainingPlayer.CustomProperties.ContainsKey(key))
                 {
                     newProperties[key] = otherPlayer.CustomProperties[key];
                 }
@@ -314,14 +313,14 @@ public class RoomManager : MonoBehaviourPunCallbacks
             remainingPlayer.SetCustomProperties(newProperties);
 
             // 매튜를 흑백처리
-            player2Image.sprite = matthewBWImage;
+            matthewImage.sprite = matthewBWImage;
             // You 
             UpdatePlayerIndicator();
             // 버튼 조작권한
-            SetReadyButtonInteractivity();
-            if(PhotonNetwork.LocalPlayer.CustomProperties.ContainsKey("Ready"))
+            //SetReadyButtonInteractivity();
+            if (PhotonNetwork.LocalPlayer.CustomProperties.ContainsKey("Ready"))
             {
-                player1ReadyText.text = (bool)PhotonNetwork.LocalPlayer.CustomProperties["Ready"] ? "Ready!" : "";
+                daveReadyText.text = (bool)PhotonNetwork.LocalPlayer.CustomProperties["Ready"] ? "Ready!" : "";
             }
         }
     }

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -1,0 +1,5 @@
+{
+    "m_Dictionary": {
+        "m_DictionaryValues": []
+    }
+}


### PR DESCRIPTION

https://github.com/user-attachments/assets/e1bc44eb-e6c7-4052-9951-7f0d400b5e35

### 작업 내용
* 룸 씬에서 있던 버그를 수정했습니다.
=== 목록 ===
* 플레이어 한 명이 나갔을 때 나머지 클라이언트에 반영되지 않던 점
* 한 명이 나갔다가 다시 들어오는 것도 클라이언트에 반영되지 않던 점
* ready 버튼을 눌렀을 때 상대 클라이언트에 반영되지 않던 점
* 캐릭터 전환 시에 ready 버튼 상태, 버튼 사용가능 여부가 반영되지 않던 점
* 두명 모두 ready 했어도 5초 후 게임이 시작되지 않던 점 / 5초 중 ready를 취소하면 게임 시작 보류 기능 추가
* 이외 기억 안 나는 것들..?

### 특이사항
* 원래 룸에서 플레이어가 안 들어왔을 때는 흑백 이미지를 쓰기로 했는데 현석이한테 파일이 있어서 임시로 아무 스프라이트나 넣었습니다.. 나중에 수정해주세요오

### Merge 데드라인
* 다음 회의 전까지는 읽어보고 리뷰 부탁합니답