### PR TITLE
[Refactor] 버튼 눌러서 UI 관련된 기능 UIManager로 옮기기 

### DIFF
--- a/Assets/Scenes/LobbyScene.unity
+++ b/Assets/Scenes/LobbyScene.unity
@@ -301,6 +301,59 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &185269394
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 185269395}
+  - component: {fileID: 185269396}
+  m_Layer: 0
+  m_Name: UIManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &185269395
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 185269394}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 858.2422, y: 472.80478, z: -12.093192}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &185269396
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 185269394}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f76658be6961f941815513e93e7639f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  switchButton: {fileID: 0}
+  tutorialPanel: {fileID: 0}
+  pausePanel: {fileID: 0}
+  titleExitPanel: {fileID: 0}
+  roomCodeInputPanel: {fileID: 0}
+  tutorialPanelOpen: 1
+  titleExitPanelOpen: 0
+  roomCodeInputPanelOpen: 0
+  pause: 0
 --- !u!1 &257938717
 GameObject:
   m_ObjectHideFlags: 0
@@ -1542,10 +1595,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1523785825}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 185269396}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: OpenRoomCodeInputPanel
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -2034,10 +2087,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1523785825}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 185269396}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: CloseRoomCodeInputPanel
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -2226,3 +2279,4 @@ SceneRoots:
   - {fileID: 298004861}
   - {fileID: 1265989334}
   - {fileID: 819555813}
+  - {fileID: 185269395}

--- a/Assets/Scenes/PrisonScene.unity
+++ b/Assets/Scenes/PrisonScene.unity
@@ -646,7 +646,11 @@ MonoBehaviour:
   switchButton: {fileID: 0}
   tutorialPanel: {fileID: 2146890597}
   pausePanel: {fileID: 0}
+  titleExitPanel: {fileID: 0}
+  roomCodeInputPanel: {fileID: 0}
   tutorialPanelOpen: 1
+  titleExitPanelOpen: 0
+  roomCodeInputPanelOpen: 0
   pause: 0
 --- !u!1 &228965014
 GameObject:
@@ -3500,41 +3504,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isPuzzleSuccess: 0
---- !u!1 &1330489275
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1330489276}
-  m_Layer: 5
-  m_Name: BackToGameText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1330489276
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1330489275}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1330489277
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -16504,4 +16473,3 @@ SceneRoots:
   - {fileID: 294847766}
   - {fileID: 673922408}
   - {fileID: 1284700840}
-  - {fileID: 1330489276}

--- a/Assets/Scenes/TitleScene.unity
+++ b/Assets/Scenes/TitleScene.unity
@@ -389,10 +389,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1928240745}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 1523826332}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: CloseTitleExitPanel
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -875,10 +875,10 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1928240745}
-        m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
-        m_MethodName: SetActive
-        m_Mode: 6
+      - m_Target: {fileID: 1523826332}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
+        m_MethodName: OpenTitleExitPanel
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1058,6 +1058,56 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1445332817}
   m_CullTransparentMesh: 1
+--- !u!1 &1523826331
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1523826333}
+  - component: {fileID: 1523826332}
+  m_Layer: 0
+  m_Name: UIManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1523826332
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523826331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0f76658be6961f941815513e93e7639f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  switchButton: {fileID: 0}
+  tutorialPanel: {fileID: 0}
+  pausePanel: {fileID: 0}
+  titleExitPanel: {fileID: 1928240746}
+  tutorialPanelOpen: 1
+  pause: 0
+--- !u!4 &1523826333
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1523826331}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 811.5883, y: 334.01056, z: -11.69441}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1602602500
 GameObject:
   m_ObjectHideFlags: 0
@@ -1359,3 +1409,4 @@ SceneRoots:
   - {fileID: 20954841}
   - {fileID: 1207521632}
   - {fileID: 1602602502}
+  - {fileID: 1523826333}

--- a/Assets/Scenes/TitleScene.unity
+++ b/Assets/Scenes/TitleScene.unity
@@ -521,8 +521,8 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1602602501}
-        m_TargetAssemblyTypeName: NetworkingManager, Assembly-CSharp
+      - m_Target: {fileID: 1523826332}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
         m_MethodName: LoadLobbyScene
         m_Mode: 1
         m_Arguments:
@@ -1008,8 +1008,8 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1602602501}
-        m_TargetAssemblyTypeName: NetworkingManager, Assembly-CSharp
+      - m_Target: {fileID: 1523826332}
+        m_TargetAssemblyTypeName: UIManager, Assembly-CSharp
         m_MethodName: OnExitButtonClicked
         m_Mode: 1
         m_Arguments:
@@ -1091,7 +1091,10 @@ MonoBehaviour:
   tutorialPanel: {fileID: 0}
   pausePanel: {fileID: 0}
   titleExitPanel: {fileID: 1928240746}
+  roomCodeInputPanel: {fileID: 0}
   tutorialPanelOpen: 1
+  titleExitPanelOpen: 0
+  roomCodeInputPanelOpen: 0
   pause: 0
 --- !u!4 &1523826333
 Transform:

--- a/Assets/Script/NetworkingManager.cs
+++ b/Assets/Script/NetworkingManager.cs
@@ -67,32 +67,12 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
         Debug.Log("Photon Master 서버에 연결되었습니다.");
         PhotonNetwork.JoinLobby();
     }
-
-    // TitleScene에서 Start 버튼 클릭 시 GameLobby 씬으로 이동
-    // PrisonMap에서 MapClear시 MapClearPanel에서 로비로 이동하기 버튼 클릭 시 GameLobby 씬으로 이동
-    public void LoadLobbyScene()
-    {
-        SceneManager.LoadScene("LobbyScene");
-    }
-
     // PrisonMap에서 MapClear시 MapClearPanel에서 계속하기 버튼을 클릭 시 MapChoose 씬으로 이동
     public void LoadMapChooseScene()
     {
         SceneManager.LoadScene("MapChooseScene");
     }
 
-    // Exit 버튼 클릭 시 게임 종료
-    public void OnExitButtonClicked()
-    {
-        // 에디터와 프로그램 실행을 구분.
-        #if UNITY_EDITOR
-            UnityEditor.EditorApplication.isPlaying = false;
-        #else
-            // 어플리케이션 종료
-            Application.Quit();
-        #endif
-            Debug.Log("게임 종료");
-    }
     // 방 코드 생성 함수
     private string GenerateRoomCode()
     {

--- a/Assets/Script/NetworkingManager.cs
+++ b/Assets/Script/NetworkingManager.cs
@@ -67,12 +67,6 @@ public class NetworkingManager : MonoBehaviourPunCallbacks
         Debug.Log("Photon Master 서버에 연결되었습니다.");
         PhotonNetwork.JoinLobby();
     }
-    // PrisonMap에서 MapClear시 MapClearPanel에서 계속하기 버튼을 클릭 시 MapChoose 씬으로 이동
-    public void LoadMapChooseScene()
-    {
-        SceneManager.LoadScene("MapChooseScene");
-    }
-
     // 방 코드 생성 함수
     private string GenerateRoomCode()
     {

--- a/Assets/Script/StageManagerScript.cs
+++ b/Assets/Script/StageManagerScript.cs
@@ -143,17 +143,4 @@ public class StageManager : MonoBehaviour
         isTimeOver = true;
     }
 
-
-    public void OnBackToLobbyButtonClicked()
-{
-    if (NetworkingManager.Instance != null)
-    {
-        NetworkingManager.Instance.LoadLobbyScene();
-    }
-    else
-    {
-        Debug.LogError("NetworkingManager instance is null.");
-    }
-}
-
 }

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;  
+using UnityEngine.SceneManagement;
 using Photon.Pun;
 
 public class UIManager : MonoBehaviour
@@ -8,7 +9,9 @@ public class UIManager : MonoBehaviour
     public Button switchButton;
     public RectTransform tutorialPanel;
     public RectTransform pausePanel;
+    public RectTransform titleExitPanel;
     public bool tutorialPanelOpen = true;
+    public bool titleExitPanelOpen = false;
     public bool pause = false;
 
     private void Start()
@@ -81,5 +84,17 @@ public class UIManager : MonoBehaviour
         pause = false;
         Time.timeScale = 1;
         pausePanel.gameObject.SetActive(false);
+    }
+
+    public void OpenTitleExitPanel()
+    {
+        titleExitPanelOpen = true;
+        titleExitPanel.gameObject.SetActive(titleExitPanelOpen);
+    }
+
+    public void CloseTitleExitPanel()
+    {
+        titleExitPanelOpen = false;
+        titleExitPanel.gameObject.SetActive(false);
     }
 }

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -117,7 +117,7 @@ public class UIManager : MonoBehaviour
 
     public void LoadMapChooseScene()
     {
-        SceneManager.LoadScene("MapChooseScene");
+        PhotonNetwork.LoadLevel("MapChooseScene"); 
     }
 
     // Title

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -34,20 +34,30 @@ public class UIManager : MonoBehaviour
 
     private void Update()
     {
-        // TutorialPanel이 열려있고, Pause가 비활성화 되어있을때, ESC 눌렀을때 TutorialPanel 닫히게 하고 싶음.
-        if(tutorialPanelOpen && !pause && Input.GetKeyDown(KeyCode.Escape))
+        if(SceneManager.GetActiveScene().name == "PrisonScene" || SceneManager.GetActiveScene().name == "HouseScene")
         {
-            CloseTutorialPanel();
+            // TutorialPanel이 열려있고, Pause가 비활성화 되어있을때, ESC 눌렀을때 TutorialPanel 닫히게 하고 싶음.
+            if(tutorialPanelOpen && !pause && Input.GetKeyDown(KeyCode.Escape))
+            {
+                CloseTutorialPanel();
+            }
+            // TutorialPanel이 닫혀있고, Pause가 비활성화 되었있을때, ESC를 누르면 일시정지 창이 나옴.
+            else if(!tutorialPanelOpen && !pause && Input.GetKeyDown(KeyCode.Escape))
+            {
+                OpenEscPanel();
+            }
+            // TutorialPanel이 닫혀있고, Pause가 활성화 되어있을때, ESC를 누르면 일시정지 창이 닫힘.
+            else if(!tutorialPanelOpen && pause && Input.GetKeyDown(KeyCode.Escape))
+            {
+                CloseEscPanel();
+            }
         }
-        // TutorialPanel이 닫혀있고, Pause가 비활성화 되었있을때, ESC를 누르면 일시정지 창이 나옴.
-        else if(!tutorialPanelOpen && !pause && Input.GetKeyDown(KeyCode.Escape))
+        else if(SceneManager.GetActiveScene().name == "TitleScene")
         {
-            OpenEscPanel();
-        }
-        // TutorialPanel이 닫혀있고, Pause가 활성화 되어있을때, ESC를 누르면 일시정지 창이 닫힘.
-        else if(!tutorialPanelOpen && pause && Input.GetKeyDown(KeyCode.Escape))
-        {
-            CloseEscPanel();
+            if(titleExitPanelOpen && Input.GetKeyDown(KeyCode.Escape))
+            {
+                CloseTitleExitPanel();
+            }
         }
         
     }

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -79,6 +79,8 @@ public class UIManager : MonoBehaviour
         }
         
     }
+
+    // Prison & House
     public void OpenTutorialPanel()
     {
         if(!tutorialPanelOpen)
@@ -99,7 +101,6 @@ public class UIManager : MonoBehaviour
         tutorialPanel.gameObject.SetActive(tutorialPanelOpen);
     }
 
-
     public void OpenEscPanel()
     {
         pause = true;
@@ -114,6 +115,12 @@ public class UIManager : MonoBehaviour
         pausePanel.gameObject.SetActive(false);
     }
 
+    public void LoadMapChooseScene()
+    {
+        SceneManager.LoadScene("MapChooseScene");
+    }
+
+    // Title
     public void OpenTitleExitPanel()
     {
         titleExitPanelOpen = true;
@@ -126,6 +133,17 @@ public class UIManager : MonoBehaviour
         titleExitPanel.gameObject.SetActive(false);
     }
 
+    public void OnExitButtonClicked()
+    {
+        #if UNITY_EDITOR
+            UnityEditor.EditorApplication.isPlaying = false;
+        #else
+            Application.Quit();
+        #endif
+            Debug.Log("게임 종료");
+    }
+    
+    // Lobby
     public void OpenRoomCodeInputPanel()
     {
         roomCodeInputPanelOpen = true;
@@ -145,22 +163,5 @@ public class UIManager : MonoBehaviour
     {
         SceneManager.LoadScene("LobbyScene");
     } 
-    
-    // MapClearPanel -> ContinueButton
-    public void LoadMapChooseScene()
-    {
-        SceneManager.LoadScene("MapChooseScene");
-    }
-
-    // TitleScene -> ExitButton
-    public void OnExitButtonClicked()
-    {
-        #if UNITY_EDITOR
-            UnityEditor.EditorApplication.isPlaying = false;
-        #else
-            Application.Quit();
-        #endif
-            Debug.Log("게임 종료");
-    }
 
 }

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -149,6 +149,12 @@ public class UIManager : MonoBehaviour
         SceneManager.LoadScene("LobbyScene");
     } 
     
+    // MapClearPanel -> ContinueButton
+    public void LoadMapChooseScene()
+    {
+        SceneManager.LoadScene("MapChooseScene");
+    }
+
     // TitleScene -> ExitButton
     public void OnExitButtonClicked()
     {

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -45,17 +45,14 @@ public class UIManager : MonoBehaviour
     {
         if(SceneManager.GetActiveScene().name == "PrisonScene" || SceneManager.GetActiveScene().name == "HouseScene")
         {
-            // TutorialPanel이 열려있고, Pause가 비활성화 되어있을때, ESC 눌렀을때 TutorialPanel 닫히게 하고 싶음.
             if(tutorialPanelOpen && !pause && Input.GetKeyDown(KeyCode.Escape))
             {
                 CloseTutorialPanel();
             }
-            // TutorialPanel이 닫혀있고, Pause가 비활성화 되었있을때, ESC를 누르면 일시정지 창이 나옴.
             else if(!tutorialPanelOpen && !pause && Input.GetKeyDown(KeyCode.Escape))
             {
                 OpenEscPanel();
             }
-            // TutorialPanel이 닫혀있고, Pause가 활성화 되어있을때, ESC를 누르면 일시정지 창이 닫힘.
             else if(!tutorialPanelOpen && pause && Input.GetKeyDown(KeyCode.Escape))
             {
                 CloseEscPanel();

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -16,7 +16,14 @@ public class UIManager : MonoBehaviour
 
     private void Start()
     {
-        tutorialPanel.gameObject.SetActive(tutorialPanelOpen);
+        if(SceneManager.GetActiveScene().name == "PrisonScene" || SceneManager.GetActiveScene().name == "HouseScene")
+        {
+            tutorialPanel.gameObject.SetActive(tutorialPanelOpen);
+        }
+        else 
+        {
+            return;
+        }
         // NetworkingManager가 로드될 때까지 기다린 후, 버튼 이벤트 연결
         if (PhotonNetwork.IsConnected)
         {

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -141,4 +141,23 @@ public class UIManager : MonoBehaviour
         roomCodeInputPanel.gameObject.SetActive(roomCodeInputPanelOpen);
     }
     
+
+    // TitleScene -> StartButton
+    // MapClearPanel -> BackToLobbyButton
+    public void LoadLobbyScene()
+    {
+        SceneManager.LoadScene("LobbyScene");
+    } 
+    
+    // TitleScene -> ExitButton
+    public void OnExitButtonClicked()
+    {
+        #if UNITY_EDITOR
+            UnityEditor.EditorApplication.isPlaying = false;
+        #else
+            Application.Quit();
+        #endif
+            Debug.Log("게임 종료");
+    }
+
 }

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -114,4 +114,17 @@ public class UIManager : MonoBehaviour
         titleExitPanelOpen = false;
         titleExitPanel.gameObject.SetActive(false);
     }
+
+    public void OpenRoomCodeInputPanel()
+    {
+        roomCodeInputPanelOpen = true;
+        roomCodeInputPanel.gameObject.SetActive(roomCodeInputPanelOpen);
+    }
+
+    public void CloseRoomCodeInputPanel()
+    {
+        roomCodeInputPanelOpen = false;
+        roomCodeInputPanel.gameObject.SetActive(roomCodeInputPanelOpen);
+    }
+    
 }

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -10,8 +10,10 @@ public class UIManager : MonoBehaviour
     public RectTransform tutorialPanel;
     public RectTransform pausePanel;
     public RectTransform titleExitPanel;
+    public RectTransform roomCodeInputPanel;
     public bool tutorialPanelOpen = true;
     public bool titleExitPanelOpen = false;
+    public bool roomCodeInputPanelOpen = false;
     public bool pause = false;
 
     private void Start()
@@ -65,6 +67,18 @@ public class UIManager : MonoBehaviour
             {
                 CloseTitleExitPanel();
             }
+        }
+        else if(SceneManager.GetActiveScene().name == "LobbyScene")
+        {
+            if(!roomCodeInputPanelOpen && Input.GetKeyDown(KeyCode.Escape))
+            {
+                SceneManager.LoadScene("TitleScene");
+            }
+            else if(roomCodeInputPanelOpen && Input.GetKeyDown(KeyCode.Escape))
+            {
+                CloseRoomCodeInputPanel();
+            }
+            
         }
         
     }


### PR DESCRIPTION
## 작업 내용
### Title
1. UIManager Object 추가
2. StartButton -> NetWorkingManager에서의 LoadScene("LobbyScene")을 UIManager로 옮김.
3. ExitButton -> Button OnClick()에서 UIManager OpenTitleExitModal()로 리펙토링.
4. ExitModal에서 YesButton -> NetWorkManager에서의 OnExitButtonClicked를 UIManager로 옮김.
5. ExitModal에서 NoButton -> Button OnClick()에서 UIManager CloseTitleExitModal()로 리펙토링.
6. ExitModal창이 켜져있을경우, ESC를 눌렀을때 닫힘.

### Lobby
1. LobbyScene에서 ESC를 누르면 TitleScene으로 이동.
2. InputRoomCodeButton -> Button OnClick()에서 UIManager OpenRoomCodeInputModal()로 리펙토링.
3. RoomCodeInputModal에서 CloseModalButton -> Button OnClick()에서 UIManager CloseRoomCodeInputModal()로 리펙토링.
4. RoomCodeInputModal이 켜져있을경우, ESC를 눌렀을때 닫힘

### Prison & House
현재 이슈
1. GameClearModal창이 날라감.
2. PauseModal창이 날라감. 
-> 네트워크 건들면서 다시 만들겠음.

작업내용
1. NetWorkingManager에서 다루던 LoadLobbyScene을 UIManager로 옮김.
2. NetWorkingManager에서 다루던 LoadMapChooseScene을 UIManager로 옮김.