### PR TITLE
[Fix] 타이틀 ~ 튜토리얼까지 버튼 - UI 로직 픽스

### DIFF
--- a/Assets/Scenes/LobbyScene.unity
+++ b/Assets/Scenes/LobbyScene.unity
@@ -312,7 +312,7 @@ GameObject:
   - component: {fileID: 185269395}
   - component: {fileID: 185269396}
   m_Layer: 0
-  m_Name: UIManager
+  m_Name: LobbyUIManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -345,11 +345,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f76658be6961f941815513e93e7639f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  switchButton: {fileID: 0}
   tutorialPanel: {fileID: 0}
   pausePanel: {fileID: 0}
   titleExitPanel: {fileID: 0}
-  roomCodeInputPanel: {fileID: 0}
+  roomCodeInputPanel: {fileID: 1523785826}
   tutorialPanelOpen: 1
   titleExitPanelOpen: 0
   roomCodeInputPanelOpen: 0
@@ -1965,7 +1964,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1897779721}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1265989333}
+        m_TargetAssemblyTypeName: LobbyManager, Assembly-CSharp
+        m_MethodName: OnQuickMatch
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1897779721
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2222,7 +2233,7 @@ MonoBehaviour:
       m_Calls:
       - m_Target: {fileID: 1265989333}
         m_TargetAssemblyTypeName: LobbyManager, Assembly-CSharp
-        m_MethodName: MakeRoom
+        m_MethodName: OnMakeRoom
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scenes/PrisonScene.unity
+++ b/Assets/Scenes/PrisonScene.unity
@@ -610,7 +610,7 @@ GameObject:
   - component: {fileID: 148467858}
   - component: {fileID: 148467859}
   m_Layer: 0
-  m_Name: UIManager
+  m_Name: PrisonUIManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -643,7 +643,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f76658be6961f941815513e93e7639f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  switchButton: {fileID: 0}
   tutorialPanel: {fileID: 2146890597}
   pausePanel: {fileID: 0}
   titleExitPanel: {fileID: 0}

--- a/Assets/Scenes/RoomScene.unity
+++ b/Assets/Scenes/RoomScene.unity
@@ -2598,7 +2598,7 @@ GameObject:
   - component: {fileID: 2031633106}
   - component: {fileID: 2031633105}
   m_Layer: 0
-  m_Name: UIManager
+  m_Name: RoomUIManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Scenes/TitleScene.unity
+++ b/Assets/Scenes/TitleScene.unity
@@ -1069,7 +1069,7 @@ GameObject:
   - component: {fileID: 1523826333}
   - component: {fileID: 1523826332}
   m_Layer: 0
-  m_Name: UIManager
+  m_Name: TitleUIManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1087,7 +1087,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f76658be6961f941815513e93e7639f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  switchButton: {fileID: 0}
   tutorialPanel: {fileID: 0}
   pausePanel: {fileID: 0}
   titleExitPanel: {fileID: 1928240746}
@@ -1410,6 +1409,6 @@ SceneRoots:
   m_Roots:
   - {fileID: 1706471177}
   - {fileID: 20954841}
+  - {fileID: 1523826333}
   - {fileID: 1207521632}
   - {fileID: 1602602502}
-  - {fileID: 1523826333}

--- a/Assets/Script/LobbyManager.cs
+++ b/Assets/Script/LobbyManager.cs
@@ -21,7 +21,7 @@ public class LobbyManager : MonoBehaviour
     }
 
     // QuickMatch 버튼 클릭 시 호출
-    private void OnQuickMatch()
+    public void OnQuickMatch()
     {
         // 랜덤 매칭
         if (PhotonNetwork.IsConnectedAndReady)
@@ -36,7 +36,7 @@ public class LobbyManager : MonoBehaviour
     }
 
     // 방 생성 버튼 클릭 시 호출
-    private void OnMakeRoom()
+    public void OnMakeRoom()
     {
         // NetworkingManager를 통해 방 생성 요청하기
         NetworkingManager.Instance.CreateRoom();

--- a/Assets/Script/UIManager.cs
+++ b/Assets/Script/UIManager.cs
@@ -5,7 +5,6 @@ using Photon.Pun;
 
 public class UIManager : MonoBehaviour
 {
-    public static UIManager instance;
     public RectTransform tutorialPanel;
     public RectTransform pausePanel;
     public RectTransform titleExitPanel;
@@ -15,29 +14,13 @@ public class UIManager : MonoBehaviour
     public bool roomCodeInputPanelOpen = false;
     public bool pause = false;
 
-     private void Awake()
-    {
-        // 싱글톤 패턴 구현: UIManager가 중복되지 않도록 설정
-        if (instance != null && instance != this)
-        {
-            Destroy(gameObject);
-        }
-        else
-        {
-            instance = this;
-            // 씬 전환 시에도 파괴되지 않도록 설정
-            DontDestroyOnLoad(gameObject);
-        }
-    }
+    // 기존에 있던 싱글톤 패턴을 해제하고 씬마다의 UiManager에게 공통 스크립트를 부여, 해당 씬에 있는 버튼만 사용하게 합니다
+    // 앞으로 추가되는 버튼들도 이곳에 추가 / 할당한 후 사용하되, 절대 그 씬에 존재하지 않는 버튼을 사용하는 로직을 추가하지 마세요! 바로 오류납니다
     private void Start()
     {
         if(SceneManager.GetActiveScene().name == "PrisonScene" || SceneManager.GetActiveScene().name == "HouseScene")
         {
             tutorialPanel.gameObject.SetActive(tutorialPanelOpen);
-        }
-        else 
-        {
-            return;
         }
     }
 


### PR DESCRIPTION
### 작업 내용
* 통합 싱글톤 UI 패턴을 해제하고, 각 씬마다 공통된 스크립트로 UI를 관리하도록 개선했습니다.
* 끊어졌던 컴포넌트는 복구하고, 아직 복구되지 않은 UI 컴포넌트는 비워 두었습니다(Pause UI).

### 특이사항
* UIManager.cs를 통해 각 씬별 UI 매니저를 만들었지만 아직 이곳에서 관리되지 않는 UI 로직 / 이곳에서 관리될 수 없는 UI 로직들이 다수 존재합니다. 또한 씬이 바뀜에 따라 스크립트에 할당되는 버튼 중 None 오브젝트가 다수 발생하고, 이 None 오브젝트를 참조하게 되는 로직이 실행되면 바로 오류가 발생합니다.. 따라서 추후 추가되는 UI / 버튼 로직은 UIManager가 아닌 각 StageManager에서 미리 할당해둔 후 StageManager에서 작동되도록 작성하는 것을 권장합니다.

### Merge 데드라인
* 추가 기능을 구현한 게 아니고 간단히 버그만 픽스한 것이기 때문에 코드를 깊게 읽어볼 내용은 없다고 생각합니다. 가급적 이 PR 읽은 시점에 리뷰 / 승인 부탁드립니다 :)