### PR TITLE
[Fix] #150에서 잡지 못한 버그 픽스

### DIFF
--- a/Assets/Resources/Player1.prefab
+++ b/Assets/Resources/Player1.prefab
@@ -349,7 +349,7 @@ Camera:
     y: 0
     width: 0.5
     height: 1
-  near clip plane: 0
+  near clip plane: 0.01
   far clip plane: 1000
   field of view: 60
   orthographic: 1

--- a/Assets/Resources/Player2.prefab
+++ b/Assets/Resources/Player2.prefab
@@ -396,7 +396,7 @@ Camera:
     y: 0
     width: 0.5
     height: 1
-  near clip plane: 0
+  near clip plane: 0.01
   far clip plane: 1000
   field of view: 60
   orthographic: 1

--- a/Assets/Scenes/HouseScene.unity
+++ b/Assets/Scenes/HouseScene.unity
@@ -537,7 +537,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Sprite: {fileID: 7482667652216324306, guid: fdee3a0df83ab5d4896a6e4eaa80b18c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_FlipX: 0
   m_FlipY: 0
@@ -1017,7 +1017,7 @@ Transform:
   m_GameObject: {fileID: 593874986}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 4.84, y: -5.41, z: 0}
+  m_LocalPosition: {x: 4.84, y: -5.41, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1036,7 +1036,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
+  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
   objectIndex: 6
   stageManager: {fileID: 1748221699}
   playerLocations: []
@@ -1411,7 +1411,7 @@ Transform:
   m_GameObject: {fileID: 872800547}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.27, y: -4.73, z: 0}
+  m_LocalPosition: {x: -3.27, y: -4.73, z: 1}
   m_LocalScale: {x: 1, y: 1.8635, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1482,7 +1482,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
+  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
   objectIndex: 2
   stageManager: {fileID: 1748221699}
   playerLocation: {fileID: 0}
@@ -1626,7 +1626,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!4 &882575294
@@ -1811,7 +1811,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!4 &952393423
@@ -2383,7 +2383,7 @@ Transform:
   m_GameObject: {fileID: 1236432511}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.18, y: -5.35, z: -0.5}
+  m_LocalPosition: {x: -6.18, y: -5.35, z: 1}
   m_LocalScale: {x: 0.8346, y: 0.7979, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2402,7 +2402,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
+  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
   stageManager: {fileID: 1748221699}
   playerLocation: {fileID: 0}
   canHoldDistance: 2
@@ -3049,7 +3049,7 @@ Transform:
   m_GameObject: {fileID: 1514945337}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -10.54, y: -4.74, z: 0}
+  m_LocalPosition: {x: -10.54, y: -4.74, z: 1}
   m_LocalScale: {x: 1.3, y: 1.3, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3068,7 +3068,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
+  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
   objectIndex: 0
   stageManager: {fileID: 1748221699}
   playerLocations: []
@@ -3230,7 +3230,7 @@ Transform:
   m_GameObject: {fileID: 1521573601}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.32, y: -5.38, z: 0}
+  m_LocalPosition: {x: 1.32, y: -5.38, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3249,7 +3249,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
+  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
   objectIndex: 4
   stageManager: {fileID: 1748221699}
   playerLocations: []
@@ -3488,7 +3488,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
+  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
   objectIndex: 5
   stageManager: {fileID: 1748221699}
   fuseInteractZone: {fileID: 191372674}
@@ -3601,7 +3601,7 @@ Transform:
   m_GameObject: {fileID: 1570227786}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.14, y: -5.37, z: 0}
+  m_LocalPosition: {x: 3.14, y: -5.37, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3837,7 +3837,7 @@ Transform:
   m_GameObject: {fileID: 1627279844}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -8.71, y: -4.9, z: 0}
+  m_LocalPosition: {x: -8.71, y: -4.9, z: 1}
   m_LocalScale: {x: 1.4484, y: 1.275211, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3908,7 +3908,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
+  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
   objectIndex: 1
   stageManager: {fileID: 1748221699}
   playerLocations: []
@@ -4500,7 +4500,7 @@ Transform:
   m_GameObject: {fileID: 1822420503}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.77, y: -5.38, z: 0}
+  m_LocalPosition: {x: -0.77, y: -5.38, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4519,7 +4519,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
+  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
   objectIndex: 3
   stageManager: {fileID: 1748221699}
   playerLocations: []
@@ -4738,7 +4738,7 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 1, y: 1}
-    newSize: {x: 1, y: 1}
+    newSize: {x: 2.56, y: 2.56}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
@@ -4758,6 +4758,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e35b8edf9b042764f882bb28ba5f2cc2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  player1InZone: 0
+  player2InZone: 0
   stageManager: {fileID: 1748221699}
   stageClear: 0
   MapClearPanel: {fileID: 0}
@@ -4803,12 +4805,12 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Sprite: {fileID: 7482667652216324306, guid: fdee3a0df83ab5d4896a6e4eaa80b18c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 0.043137256}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 2.56, y: 2.56}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -4823,7 +4825,7 @@ Transform:
   m_GameObject: {fileID: 1956038720}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5.71, y: -8.96, z: 0}
+  m_LocalPosition: {x: 5.71, y: -8.96, z: 1}
   m_LocalScale: {x: 1.5992, y: 3.8676, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5008,7 +5010,7 @@ Transform:
   m_GameObject: {fileID: 2094775840}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.24, y: -6.1919, z: 0}
+  m_LocalPosition: {x: -3.24, y: -6.1919, z: 1}
   m_LocalScale: {x: 1.712077, y: 1.0108743, z: 1.712077}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -5124,7 +5126,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: 0e469783926eb7e4baeec88270a07c91, type: 2}
+  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
   sr: {fileID: 0}
   daveBox: {fileID: 1236432511}
 --- !u!1 &2095312401

--- a/Assets/Scenes/HouseScene.unity
+++ b/Assets/Scenes/HouseScene.unity
@@ -5126,7 +5126,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   normalState: {fileID: 2100000, guid: 156e2e5d3e19cf743a21910567fd6e66, type: 2}
-  canInteractState: {fileID: 2100000, guid: e6d0bc543f597f84f9b6ef33df0aff8f, type: 2}
+  canInteractState: {fileID: 2100000, guid: 1a0517ea99bbc3e45bc921cbe1b5dec6, type: 2}
   sr: {fileID: 0}
   daveBox: {fileID: 1236432511}
 --- !u!1 &2095312401

--- a/Assets/Scenes/HouseScene.unity
+++ b/Assets/Scenes/HouseScene.unity
@@ -1017,7 +1017,7 @@ Transform:
   m_GameObject: {fileID: 593874986}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 4.84, y: -5.41, z: 1}
+  m_LocalPosition: {x: 5.12, y: -5.11, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1040,7 +1040,7 @@ MonoBehaviour:
   objectIndex: 6
   stageManager: {fileID: 1748221699}
   playerLocations: []
-  interactionDistance: 2
+  interactionDistance: 1.5
   hasInteracted: 0
   sr: {fileID: 0}
   PuzzleUI: {fileID: 222962354}
@@ -1618,7 +1618,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: -2413806693520163455, guid: 34a924f8a507e2c46a08cc936c2de72f, type: 3}
   m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -1626,7 +1626,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
+  m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!4 &882575294
@@ -1803,7 +1803,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Sprite: {fileID: -2413806693520163455, guid: 34a924f8a507e2c46a08cc936c2de72f, type: 3}
   m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -1811,7 +1811,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
+  m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!4 &952393423
@@ -3230,7 +3230,7 @@ Transform:
   m_GameObject: {fileID: 1521573601}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.32, y: -5.38, z: 1}
+  m_LocalPosition: {x: 1.28, y: -4.97, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3253,7 +3253,7 @@ MonoBehaviour:
   objectIndex: 4
   stageManager: {fileID: 1748221699}
   playerLocations: []
-  interactionDistance: 2
+  interactionDistance: 1.5
   hasInteracted: 0
   sr: {fileID: 0}
   PuzzleUI: {fileID: 222962354}
@@ -4523,7 +4523,7 @@ MonoBehaviour:
   objectIndex: 3
   stageManager: {fileID: 1748221699}
   playerLocations: []
-  interactionDistance: 2
+  interactionDistance: 1.5
   hasInteracted: 0
   sr: {fileID: 0}
   PuzzleUI: {fileID: 222962354}

--- a/Assets/Scenes/HouseScene.unity
+++ b/Assets/Scenes/HouseScene.unity
@@ -1040,7 +1040,7 @@ MonoBehaviour:
   objectIndex: 6
   stageManager: {fileID: 1748221699}
   playerLocations: []
-  interactionDistance: 1.5
+  interactionDistance: 2
   hasInteracted: 0
   sr: {fileID: 0}
   PuzzleUI: {fileID: 222962354}
@@ -1486,7 +1486,7 @@ MonoBehaviour:
   objectIndex: 2
   stageManager: {fileID: 1748221699}
   playerLocation: {fileID: 0}
-  interactionDistance: 1.3
+  interactionDistance: 2.5
   hasInteracted: 0
   houseShelf: {fileID: 872800547}
   sr: {fileID: 0}
@@ -3253,7 +3253,7 @@ MonoBehaviour:
   objectIndex: 4
   stageManager: {fileID: 1748221699}
   playerLocations: []
-  interactionDistance: 1.5
+  interactionDistance: 2
   hasInteracted: 0
   sr: {fileID: 0}
   PuzzleUI: {fileID: 222962354}
@@ -3912,7 +3912,7 @@ MonoBehaviour:
   objectIndex: 1
   stageManager: {fileID: 1748221699}
   playerLocations: []
-  interactionDistance: 1.3
+  interactionDistance: 2.5
   hasInteracted: 0
   sr: {fileID: 0}
   PuzzleUI: {fileID: 222962354}
@@ -4523,7 +4523,7 @@ MonoBehaviour:
   objectIndex: 3
   stageManager: {fileID: 1748221699}
   playerLocations: []
-  interactionDistance: 1.5
+  interactionDistance: 2
   hasInteracted: 0
   sr: {fileID: 0}
   PuzzleUI: {fileID: 222962354}

--- a/Assets/Scenes/PuzzleScene/HousePuzzleScene/HouseFuseBoxPuzzleScene.unity
+++ b/Assets/Scenes/PuzzleScene/HousePuzzleScene/HouseFuseBoxPuzzleScene.unity
@@ -2531,7 +2531,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Sprite: {fileID: 7482667652216324306, guid: fdee3a0df83ab5d4896a6e4eaa80b18c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -2539,7 +2539,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 0
+  m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!4 &1583759363

--- a/Assets/Scenes/PuzzleScene/HousePuzzleScene/HouseShelfPuzzleScene.unity
+++ b/Assets/Scenes/PuzzleScene/HousePuzzleScene/HouseShelfPuzzleScene.unity
@@ -572,7 +572,7 @@ Transform:
   m_GameObject: {fileID: 1276170617}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -44.75, y: -52.68, z: -1}
+  m_LocalPosition: {x: -42.37, y: -53.69, z: -1}
   m_LocalScale: {x: 1.7158, y: 2.6463, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Script/HouseSceneScript/HouseInteractScript/DaveBoxInteractScript.cs
+++ b/Assets/Script/HouseSceneScript/HouseInteractScript/DaveBoxInteractScript.cs
@@ -106,17 +106,6 @@ public class DaveBoxInteractScript : MonoBehaviourPun
             if (Input.GetKeyDown(KeyCode.Space))
             {
                 photonView.RPC("HoldingEndRPC", RpcTarget.All);
-                // 투명도 조정
-                SpriteRenderer spriteRenderer = boxDestination.GetComponent<SpriteRenderer>();
-
-                if (spriteRenderer != null)
-                {
-                    Color color = spriteRenderer.color;
-                    // a값(투명도) 재조절
-                    color.a = 0;
-                    // 변경된 색상 다시 할당
-                    spriteRenderer.color = color;
-                }
             }
         }
     }
@@ -138,10 +127,23 @@ public class DaveBoxInteractScript : MonoBehaviourPun
     {
         isHolding = false;
         // 목적지의 x,y 좌표 가져와서 박스 두기
-        transform.position = new Vector3(boxDestination.GetComponent<Transform>().position.x, boxDestination.GetComponent<Transform>().position.y + 0.3f, -1.0f);
+        transform.position = new Vector3(boxDestination.GetComponent<Transform>().position.x, boxDestination.GetComponent<Transform>().position.y + 0.3f, 0.9f);
         boxInteractEnd = true;
         // 선반에 박스 도착했다고 알리기
         matthewShelf.GetComponent<MatthewShelfInteractScript>().isBoxArrived = true;
+        // 도착지 상태 갱신
+        boxDestination.GetComponent<BoxDestinationZoneScript>().sr.material = normalState;
+        // 투명도 조정
+        SpriteRenderer spriteRenderer = boxDestination.GetComponent<SpriteRenderer>();
+
+        if (spriteRenderer != null)
+        {
+            Color color = spriteRenderer.color;
+            // a값(투명도) 재조절
+            color.a = 0;
+            // 변경된 색상 다시 할당
+            spriteRenderer.color = color;
+        }
     }
 
 

--- a/Assets/Script/HouseSceneScript/HouseInteractScript/DaveBoxInteractScript.cs
+++ b/Assets/Script/HouseSceneScript/HouseInteractScript/DaveBoxInteractScript.cs
@@ -50,7 +50,7 @@ public class DaveBoxInteractScript : MonoBehaviourPun
 
     void Update()
     {
-        if(playerLocation == null)
+        if (playerLocation == null)
         {
             AddLocalPlayer();
             return;
@@ -73,7 +73,6 @@ public class DaveBoxInteractScript : MonoBehaviourPun
             {
                 PhotonView photonView = GetComponent<PhotonView>();
                 photonView.RPC("HoldingStartRPC", RpcTarget.All);
-
                 // 투명도 조정
                 SpriteRenderer spriteRenderer = boxDestination.GetComponent<SpriteRenderer>();
 
@@ -82,7 +81,7 @@ public class DaveBoxInteractScript : MonoBehaviourPun
                     Color color = spriteRenderer.color;
                     // a값(투명도) 조절
                     color.a = 0.5f;
-                     // 변경된 색상 다시 할당
+                    // 변경된 색상 다시 할당
                     spriteRenderer.color = color;
                 }
             }
@@ -107,6 +106,17 @@ public class DaveBoxInteractScript : MonoBehaviourPun
             if (Input.GetKeyDown(KeyCode.Space))
             {
                 photonView.RPC("HoldingEndRPC", RpcTarget.All);
+                // 투명도 조정
+                SpriteRenderer spriteRenderer = boxDestination.GetComponent<SpriteRenderer>();
+
+                if (spriteRenderer != null)
+                {
+                    Color color = spriteRenderer.color;
+                    // a값(투명도) 재조절
+                    color.a = 0;
+                    // 변경된 색상 다시 할당
+                    spriteRenderer.color = color;
+                }
             }
         }
     }
@@ -126,8 +136,9 @@ public class DaveBoxInteractScript : MonoBehaviourPun
     [PunRPC]
     void HoldingEndRPC()
     {
+        isHolding = false;
         // 목적지의 x,y 좌표 가져와서 박스 두기
-        transform.position = new Vector3(boxDestination.GetComponent<Transform>().position.x, boxDestination.GetComponent<Transform>().position.y + 0.3f, 0);
+        transform.position = new Vector3(boxDestination.GetComponent<Transform>().position.x, boxDestination.GetComponent<Transform>().position.y + 0.3f, -1.0f);
         boxInteractEnd = true;
         // 선반에 박스 도착했다고 알리기
         matthewShelf.GetComponent<MatthewShelfInteractScript>().isBoxArrived = true;

--- a/Assets/Script/HouseSceneScript/HouseInteractScript/FuseBoxInteractScript.cs
+++ b/Assets/Script/HouseSceneScript/HouseInteractScript/FuseBoxInteractScript.cs
@@ -47,6 +47,12 @@ public class FuseBoxInteractScript : MonoBehaviourPun
             }
         }
 
+        else
+        {
+            // 테두리 삭제
+            HideHighlight();
+        }
+
          // 퍼즐이 열려 있을 때 퍼즐을 해결하면 상호작용 성공
         if (isPuzzleOpen)
         {

--- a/Assets/Script/HouseSceneScript/HousePuzzleScript/HousePuzzle_ShelfScript/HouseShelfDustScript.cs
+++ b/Assets/Script/HouseSceneScript/HousePuzzleScript/HousePuzzle_ShelfScript/HouseShelfDustScript.cs
@@ -7,7 +7,7 @@ public class HouseShelfPuzzleDustScript : MonoBehaviour
     // HouseShelfScript 참조(destroyPrefabCount 참조를 위함)
     private HouseShelfPuzzleScript ShelfPuzzleScript;
 
-    void Start()
+    void Awake()
     {
         // ShelfPuzzleScript를 찾아 참조
         ShelfPuzzleScript = FindObjectOfType<HouseShelfPuzzleScript>();
@@ -23,6 +23,10 @@ public class HouseShelfPuzzleDustScript : MonoBehaviour
             ShelfPuzzleScript.destroyPrefabCount++;
             // 이 프리팹 파괴
             Destroy(gameObject);
+        }
+        else
+        {
+            return;
         }
     }
 }

--- a/Assets/Script/HouseSceneScript/HousePuzzleScript/HousePuzzle_ShelfScript/HouseShelfPuzzleScript.cs
+++ b/Assets/Script/HouseSceneScript/HousePuzzleScript/HousePuzzle_ShelfScript/HouseShelfPuzzleScript.cs
@@ -15,9 +15,9 @@ public class HouseShelfPuzzleScript : MonoBehaviour
     // 파괴된 프리팹 개수
     public int destroyPrefabCount = 0;
     // 생성 범위 가장자리값 선언
-    private Vector2 maxVal = new Vector2(-44,-47.5f);
-    private Vector2 minVal = new Vector2(-56,-52.5f);
-    void Start()
+    private Vector2 maxVal = new Vector2(-45,-47.5f);
+    private Vector2 minVal = new Vector2(-56,-53f);
+    void Awake()
     {
         // 초기에 이미지 숨김
         oImage.gameObject.SetActive(false); 
@@ -31,7 +31,7 @@ public class HouseShelfPuzzleScript : MonoBehaviour
         {
             float x = Random.Range(minVal.x,maxVal.x);
             float y = Random.Range(minVal.y,maxVal.y);
-            Vector2 spawnPosition = new Vector2(x, y);
+            Vector3 spawnPosition = new Vector3(x, y, -1);
             int randIdx = Random.Range(0,dustPrefabList.Count);
             // 프리팹 생성
             Instantiate(dustPrefabList[randIdx], spawnPosition, Quaternion.identity);

--- a/Assets/Script/RoomManager.cs
+++ b/Assets/Script/RoomManager.cs
@@ -174,7 +174,10 @@ public class RoomManager : MonoBehaviourPunCallbacks
 
         // 카운트다운 종료 시 텍스트 초기화 및 게임 씬 로드
         countdownText.text = "";
-        PhotonNetwork.LoadLevel("PrisonScene");
+        if(PhotonNetwork.IsMasterClient)
+        {
+            PhotonNetwork.LoadLevel("PrisonScene");
+        }
     }
 
     public void ReadyUpDave()

--- a/Assets/Script/UIManager/PrisonUIManager.cs
+++ b/Assets/Script/UIManager/PrisonUIManager.cs
@@ -31,8 +31,7 @@ public class PrisonUIManager : MonoBehaviour
             Debug.Log("Z 눌려짐 - DestroyPlayers 호출");
             // 파괴할 프리팹 네트워킹매니저에 저장
             NetworkingManager.Instance.InsertDestroyPlayerPrefab();
-            // 씬 로드
-            PhotonNetwork.LoadLevel("HouseScene");
+            photonView.RPC("LoadHouseScene", RpcTarget.MasterClient);
         }
 
         if (tutorialPanelOpen && !isPaused && Input.GetKeyDown(KeyCode.Escape))
@@ -51,11 +50,12 @@ public class PrisonUIManager : MonoBehaviour
         }
     }
 
-    // 임시 테스트용 하우스씬 로드
+    // 하우스씬 로드(마스터 클라이언트만 실행하도록 PUNRPC 호출할것!)
     [PunRPC]
     public void LoadHouseScene()
     {
-        
+        // 씬 로드
+        PhotonNetwork.LoadLevel("HouseScene");
     }
 
     public void OpenTutorialPanel()

--- a/Assets/Sprites/OutlineMaterial/HighlightState_HouseScene.mat
+++ b/Assets/Sprites/OutlineMaterial/HighlightState_HouseScene.mat
@@ -1,0 +1,106 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: HighlightState_HouseScene
+  m_Shader: {fileID: 4800000, guid: 62505ee61d20098489c6f861ed25cce1, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords:
+  - _OUTLINEENABLED_ON
+  - _OUTLINEMODE_SOLID
+  - _OUTLINEPOSITION_INSIDE_UNDER_SPRITE
+  - _OUTLINESHAPE_CONTOUR
+  - _TILEMODE_STRETCH
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _FrameTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaThreshold: 0
+    - _Angle: 45
+    - _BumpScale: 1
+    - _ConnectedAlpha: 0
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _OutlineEnabled: 1
+    - _OutlineMode: 0
+    - _OutlinePosition: 0
+    - _OutlineShape: 0
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _Thickness: 5
+    - _TileMode: 0
+    - _UVSec: 0
+    - _Weight: 0.5
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _GradientOutline1: {r: 1, g: 1, b: 1, a: 1}
+    - _GradientOutline2: {r: 1, g: 1, b: 1, a: 1}
+    - _ImageOutline: {r: 1, g: 1, b: 1, a: 1}
+    - _SolidOutline: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Sprites/OutlineMaterial/HighlightState_HouseScene.mat.meta
+++ b/Assets/Sprites/OutlineMaterial/HighlightState_HouseScene.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e6d0bc543f597f84f9b6ef33df0aff8f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### 시연 영상
* 2개로 나뉘어져 있습니다

https://github.com/user-attachments/assets/45ff34f0-3b96-486a-959e-c23b7c34bf4a


https://github.com/user-attachments/assets/5943199b-d809-454d-b7e9-a41dbff460ea



### 작업 내용
* 잡다한 버그들을 수정했습니다. 아래는 목록입니다
- [x] 끊어진 sprite들을 복구했습니다.
- [x] 데이브가 상자를 들어서 내려놓을 시 목표지점의 색상이 이상하게 튀는 버그를 픽스했습니다.
- [x] 매튜 선반 퍼즐에서 먼지 프리팹 생성 시 기존에 Vector2를 사용해 Z값이 0으로 고정되어 레이어 소팅 문제가 있었습니다. Vector3를 이용해 명시적으로 Z값을 할당하고 레이어를 정렬했습니다.
- [x] 퓨즈박스 상호작용 시 하이라이트가 사라지지 않던 버그를 픽스했습니다.
- [x] PhotonNetwork.LoadLevel을 마스터 클라이언트에서만 작동하도록 NetworkingManager.cs를 수정했습니다
- [x] PrisonUi에서 주택 씬 디버깅용으로 만든 Z키를 매튜 쪽에서도 사용 가능하도록 로직을 추가했습니다. -> 어차피 나중에 뺄 로직이긴 한데 헷갈려서 오류뜨는 걸 방지하기 위해 넣었습니다!
* 자세한 내용들은 커밋을 조금씩 나누어 두었으니 Files Changed를 확인해 주세용

### Merge 데드라인
* 오늘 내로 부탁드립니답